### PR TITLE
Target Java 7 for compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ android:
     - extra-android-support
     - extra-google-m2repository
 
+jdk:
+  - oraclejdk7
+  - oraclejdk8
+
 branches:
   except:
     - gh-pages

--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'java'
 
+sourceCompatibility = 1.7
+
 apply plugin: 'com.bmuschko.nexus'
 
 dependencies {


### PR DESCRIPTION
If you have JDK 8 installed, you get a `com.android.dx.cf.iface.ParseException: bad class file magic (cafebabe) or version (0034.0000)` exception during a build. Setting the source compatibility version to 7 fixes that. 

I'm also not a Travis expert, but I believe this config change will run the builds on both JDK 7 and JDK 8 going forward.