### PR TITLE
Add support for hyphens and underscores as values for deeplink params

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 
 final class DeepLinkEntry {
 
-  private static final String PARAM_VALUE = "([a-zA-Z0-9]*)";
+  private static final String PARAM_VALUE = "([a-zA-Z0-9_-]*)";
   private static final String PARAM = "([a-zA-Z][a-zA-Z0-9_-]*)";
   private static final String PARAM_REGEX = "\\{(" + PARAM + ")\\}";
 

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -24,4 +24,12 @@ public class DeepLinkEntryTest {
     assertThat(parameters.get("param1")).isEqualTo("12345");
     assertThat(parameters.get("param2")).isEqualTo("alice");
   }
+
+  @Test public void testParamWithSpecialCharacters() throws Exception {
+    DeepLinkEntry entry = new DeepLinkEntry(
+        "foo/{bar}", DeepLinkEntry.Type.CLASS, String.class, null);
+
+    Map<String, String> parameters = entry.getParameters("foo/hyphens-and_underscores123");
+    assertThat(parameters.get("bar")).isEqualTo("hyphens-and_underscores123");
+  }
 }


### PR DESCRIPTION
Addresses #14 (Assuming there's no real reason why these characters were excluded)