### PR TITLE
Downgrade Okio

### DIFF
--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.bmuschko.nexus'
 apply plugin: 'checkstyle'
 
 dependencies {
-    compile 'com.squareup.okio:okio:1.5.0'
+    compile 'com.squareup.okio:okio:1.4.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.0'


### PR DESCRIPTION
Latest release of OkHttp depends on Okio 1.4.0, so let's not use a
version that's newer than that to prevent issues.

@cdeonier 