### PR TITLE
Disable signing on Travis builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Here's an example where we register `SampleActivity` to pull out an ID from a de
 parameter that we'll identify with `id`.
 
 ```java
-@DeepLink("example.com/deepLink/{id}")
+@DeepLink("foo://example.com/deepLink/{id}")
 public class MainActivity extends Activity {
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);

--- a/build.gradle
+++ b/build.gradle
@@ -16,3 +16,7 @@ allprojects {
         jcenter()
     }
 }
+
+def isCi() {
+    project.hasProperty('CI') && CI.equals('true')
+}

--- a/deeplinkdispatch-processor/build.gradle
+++ b/deeplinkdispatch-processor/build.gradle
@@ -1,13 +1,9 @@
 apply plugin: 'java'
 
+sourceCompatibility = 1.7
+
 apply plugin: 'com.bmuschko.nexus'
 apply plugin: 'checkstyle'
-
-checkstyle {
-    configFile rootProject.file('checkstyle.xml')
-    showViolations true
-    configProperties = ['checkstyle.cache.file': rootProject.file('build/checkstyle.cache')]
-}
 
 dependencies {
     compile project(':deeplinkdispatch')
@@ -20,6 +16,12 @@ dependencies {
     testCompile 'com.google.testing.compile:compile-testing:0.6'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
+}
+
+checkstyle {
+    configFile rootProject.file('checkstyle.xml')
+    showViolations true
+    configProperties = ['checkstyle.cache.file': rootProject.file('build/checkstyle.cache')]
 }
 
 modifyPom {
@@ -63,7 +65,7 @@ extraArchive {
 }
 
 nexus {
-    sign = true
+    sign = !isCi()
     repositoryUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
     snapshotRepositoryUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
 }

--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -18,9 +18,6 @@ checkstyle {
     configProperties = ['checkstyle.cache.file': rootProject.file('build/checkstyle.cache')]
 }
 
-project.group = 'com.airbnb'
-project.version = PROJECT_VERSION
-
 modifyPom {
     project {
         name 'DeepLinkDispatch library'
@@ -55,6 +52,7 @@ modifyPom {
     }
 }
 
+
 extraArchive {
     sources = true
     tests = false
@@ -62,7 +60,7 @@ extraArchive {
 }
 
 nexus {
-    sign = true
+    sign = !isCi()
     repositoryUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
     snapshotRepositoryUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
 }

--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -18,6 +18,9 @@ checkstyle {
     configProperties = ['checkstyle.cache.file': rootProject.file('build/checkstyle.cache')]
 }
 
+project.group = 'com.airbnb'
+project.version = PROJECT_VERSION
+
 modifyPom {
     project {
         name 'DeepLinkDispatch library'


### PR DESCRIPTION
This fixes:
```
$ .buildscript/deploy_snapshot.sh
Deploying snapshot...
FAILURE: Build failed with an exception.
* What went wrong:
A GnuPG key ID is required for signing. Please set signing.keyId=xxxxxxxx in <USER_HOME>/.gradle/gradle.properties.
```

@cdeonier 