### PR TITLE
Apply a stricter regex when scanning DeepLinkRegistry

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -47,7 +47,7 @@ final class DeepLinkEntry {
     this.activityClass = activityClass;
     this.method = method;
     this.parameters = parsePathParameters(uri);
-    this.regex = schemeHostAndPath(uri).replaceAll(PARAM_REGEX, PARAM_VALUE);
+    this.regex = schemeHostAndPath(uri).replaceAll(PARAM_REGEX, PARAM_VALUE) + "$";
   }
 
   public Type getType() {

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkRegistryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkRegistryTest.java
@@ -32,4 +32,12 @@ public class DeepLinkRegistryTest {
 
     assertThat(registry.parseUri("http://blah/232")).isNull();
   }
+
+  @Test public void testMultipleEntries() {
+    registry.registerDeepLink("http://test", DeepLinkEntry.Type.CLASS, Integer.class, null);
+    registry.registerDeepLink("http://test/{param1}", DeepLinkEntry.Type.CLASS, String.class, null);
+
+    assertThat(registry.parseUri("http://test").getActivityClass()).isEqualTo(Integer.class);
+    assertThat(registry.parseUri("http://test/12345").getActivityClass()).isEqualTo(String.class);
+  }
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".SecondActivity"
+            android:label="@string/app_name" />
+        <activity
             android:name="com.airbnb.deeplinkdispatch.DeepLinkActivity"
             android:theme="@android:style/Theme.NoDisplay">
             <intent-filter>

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/SecondActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/SecondActivity.java
@@ -1,0 +1,15 @@
+package com.airbnb.deeplinkdispatch.sample;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import com.airbnb.deeplinkdispatch.DeepLink;
+
+@DeepLink("airbnb://example.com/deepLink/{id}")
+public class SecondActivity extends AppCompatActivity {
+
+    @Override protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+    }
+}

--- a/sample/src/main/res/menu/menu_main.xml
+++ b/sample/src/main/res/menu/menu_main.xml
@@ -1,9 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context=".MainActivity">
-    <item android:id="@+id/action_settings"
-          android:title="@string/action_settings"
-          android:orderInCategory="100"
-          app:showAsAction="never"/>
-</menu>

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/SecondActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/SecondActivityTest.java
@@ -1,0 +1,40 @@
+package com.airbnb.deeplinkdispatch.sample;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.net.Uri;
+
+import com.airbnb.deeplinkdispatch.DeepLink;
+import com.airbnb.deeplinkdispatch.DeepLinkActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+@Config(sdk = 21, manifest = "../sample/src/main/AndroidManifest.xml")
+@RunWith(RobolectricTestRunner.class)
+public class SecondActivityTest {
+    @Test
+    public void testIntent() {
+        Intent intent = new Intent(Intent.ACTION_VIEW,
+                                   Uri.parse("airbnb://example.com/deepLink/123"));
+        DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
+            .withIntent(intent).create().get();
+        ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
+
+        Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
+        assertThat(launchedIntent.getComponent(),
+                   equalTo(new ComponentName(deepLinkActivity, SecondActivity.class)));
+
+        assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+        assertThat(launchedIntent.getStringExtra(DeepLink.URI),
+                   equalTo("airbnb://example.com/deepLink/123"));
+    }
+}


### PR DESCRIPTION
Right now, the regex scheme set up in DeepLinkEntry allows for DeepLinkRegistry.parseUri to return early if there's a subset scheme already registered.

IE: 
- IndexActivity -> "foo://items"
- ShowActivity -> "foo://items/123"

Appending the `$` at the end of the regex should ensure that the whole String matches, rather than just the beginning.