### PR TITLE
Relax path matching regex even more

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 
 final class DeepLinkEntry {
 
-  private static final String PARAM_VALUE = "([a-zA-Z0-9_#!+%-]*)";
+  private static final String PARAM_VALUE = "([a-zA-Z0-9_#!+%-~\\$]*)";
   private static final String PARAM = "([a-zA-Z][a-zA-Z0-9_-]*)";
   private static final String PARAM_REGEX = "%7B(" + PARAM + ")%7D";
 

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -28,6 +28,13 @@ public class DeepLinkEntryTest {
     assertThat(parameters.get("bar")).isEqualTo("hyphens-and_underscores123");
   }
 
+  @Test public void testParamWithTildeAndDollarSign() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}");
+
+    Map<String, String> parameters = entry.getParameters("airbnb://test/tilde~dollar$ign");
+    assertThat(parameters.get("param1")).isEqualTo("tilde~dollar$ign");
+  }
+
   @Test public void testNoMatchesFound() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
 


### PR DESCRIPTION
Thanks for the library!

We'd love to use it, but we have tildes (~) and dollar signs ($) in our parameters. This PR relaxes the regex a bit more to include these.