### PR TITLE
Relax path matching for comma and dot

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -24,8 +24,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 final class DeepLinkEntry {
-
-  private static final String PARAM_VALUE = "([a-zA-Z0-9_#!+%-~\\$]*)";
+  
+  private static final String PARAM_VALUE = "([a-zA-Z0-9_#!+%-~,\\.\\$]*)";
   private static final String PARAM = "([a-zA-Z][a-zA-Z0-9_-]*)";
   private static final String PARAM_REGEX = "%7B(" + PARAM + ")%7D";
 

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -24,7 +24,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 final class DeepLinkEntry {
-  
   private static final String PARAM_VALUE = "([a-zA-Z0-9_#!+%-~,\\.\\$]*)";
   private static final String PARAM = "([a-zA-Z][a-zA-Z0-9_-]*)";
   private static final String PARAM_REGEX = "%7B(" + PARAM + ")%7D";

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -41,7 +41,7 @@ public class DeepLinkEntryTest {
     Map<String, String> parameters = entry.getParameters("airbnb://test/N1.55,22.11");
     assertThat(parameters.get("param1")).isEqualTo("N1.55,22.11");
   }
-  
+
   @Test public void testNoMatchesFound() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
 

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -35,6 +35,13 @@ public class DeepLinkEntryTest {
     assertThat(parameters.get("param1")).isEqualTo("tilde~dollar$ign");
   }
 
+  @Test public void testParamWithDotAndComma() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}");
+
+    Map<String, String> parameters = entry.getParameters("airbnb://test/N1.55,22.11");
+    assertThat(parameters.get("param1")).isEqualTo("N1.55,22.11");
+  }
+  
   @Test public void testNoMatchesFound() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
 


### PR DESCRIPTION
We use DeepLinkDispatch , it saved us a lot of work..thank you.
 in our urls we have dots and commas, PR relaxes regex to include them. 