### PR TITLE
block non-static method to avoid runtime exception

### DIFF
--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -76,6 +76,14 @@ public class DeepLinkProcessor extends AbstractProcessor {
             DeepLink.class.getSimpleName());
       }
 
+      if (kind == ElementKind.METHOD) {
+        Set<Modifier> methodModifiers = element.getModifiers();
+        if (!methodModifiers.contains(Modifier.STATIC)) {
+          error(element, "Only static methods can be annotated with @%s",
+              DeepLink.class.getSimpleName());
+        }
+      }
+
       String[] deepLinks = element.getAnnotation(DeepLink.class).value();
       DeepLinkEntry.Type type = kind == ElementKind.CLASS
           ? DeepLinkEntry.Type.CLASS : DeepLinkEntry.Type.METHOD;

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorTest.java
@@ -33,4 +33,23 @@ public class DeepLinkProcessorTest {
     + "  }\n"
     + "}\n"));
   }
+
+  @Test public void testNonStaticMethodCompileFail() {
+    JavaFileObject sampleActivity = JavaFileObjects
+        .forSourceString("SampleActivity", "package com.example;"
+                      + "import com.airbnb.deeplinkdispatch.DeepLink; "
+                      + "public class SampleActivity {"
+                      + "  @DeepLink(\"airbnb://host/{arbitraryNumber}\")"
+                      + "  public Intent intentFromNoStatic(Context context){"
+                      + "    return new Intent();"
+                      + "  }"
+                      + "}"
+        );
+
+    assert_().about(javaSource())
+        .that(sampleActivity)
+        .processedWith(new DeepLinkProcessor())
+        .failsToCompile()
+        .withErrorContaining("Only static methods can be annotated");
+  }
 }


### PR DESCRIPTION
If a non-static is annotated with `@DeepLink` and invoked by deeplink. Application would crash in method invocation.
i.e.
```java
// cause crash if airbnb://host/20 is retrieved
@DeepLink("airbnb://host/{arbitraryNumber}")
public Intent intentFromNoStatic(Context context) {
  return new Intent(context, MainActivity.class).setAction(ACTION_DEEP_LINK_COMPLEX);
}
```

Throw Exception in compile-time rather than crash in runtime.