### PR TITLE
Support templating params as 'host' of Uri

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -66,7 +66,7 @@ final class DeepLinkEntry {
    * in the URI, it will only show up once in the set.
    */
   private static Set<String> parsePathParameters(DeepLinkUri uri) {
-    Matcher matcher = Pattern.compile(PARAM_REGEX).matcher(uri.encodedPath());
+    Matcher matcher = Pattern.compile(PARAM_REGEX).matcher(uri.encodedHost() + uri.encodedPath());
     Set<String> patterns = new LinkedHashSet<>();
     while (matcher.find()) {
       patterns.add(matcher.group(1));
@@ -108,6 +108,6 @@ final class DeepLinkEntry {
   }
 
   private String schemeHostAndPath(DeepLinkUri uri) {
-    return uri.scheme() + "://" + uri.host() + parsePath(uri);
+    return uri.scheme() + "://" + uri.encodedHost() + parsePath(uri);
   }
 }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
@@ -173,6 +173,10 @@ final class DeepLinkUri {
     return host;
   }
 
+  String encodedHost() {
+    return canonicalize(host, DeepLinkUri.CONVERT_TO_URI_ENCODE_SET, true, true);
+  }
+
   /**
    * Returns the explicitly-specified port if one was provided, or the default port for this URL's
    * scheme. For example, this returns 8443 for {@code https://square.com:8443/} and 443 for {@code

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 public class DeepLinkEntryTest {
   @Test public void testSingleParam() {
@@ -91,6 +92,15 @@ public class DeepLinkEntryTest {
   @Test public void schemeWithNumbers() {
     DeepLinkEntry entry = deepLinkEntry("jackson5://example.com");
     assertThat(entry.matches("jackson5://example.com")).isTrue();
+  }
+
+  @Test public void multiplePathParams() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://{foo}/{bar}");
+
+    Map<String, String> parameters = entry.getParameters("airbnb://baz/qux");
+    assertThat(parameters)
+      .hasSize(2)
+      .contains(entry("foo", "baz"), entry("bar", "qux"));
   }
 
   private static DeepLinkEntry deepLinkEntry(String uri) {

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkRegistryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkRegistryTest.java
@@ -26,6 +26,13 @@ public class DeepLinkRegistryTest {
     assertThat(registry.parseUri("http://test/12345/alice")).isNotNull();
   }
 
+  @Test public void testHostParameter() {
+    registry.registerDeepLink(
+        "http://{param1}", DeepLinkEntry.Type.CLASS, String.class, null);
+
+    assertThat(registry.parseUri("http://test")).isNotNull();
+  }
+
   @Test public void testEntryNotFound() {
     registry.registerDeepLink(
         "http://test/{param1}/{param2}", DeepLinkEntry.Type.CLASS, String.class, null);


### PR DESCRIPTION
DLD seems to assume that all templating happens on "path parameters", and never on the "host" parameter. (i.e. airbnb://foo/{bar} is valid, but airbnb://{bar} is not.)

If the host field is encoded as well (another tweak that has to be added to HttpUrl), and also examined for path parameters - then this works as expected.