### PR TITLE
Broadcast intent via LocalBroadcastManager

### DIFF
--- a/deeplinkdispatch-processor/build.gradle
+++ b/deeplinkdispatch-processor/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.0'
     testCompile 'com.google.android:android:4.1.1.4'
+    testCompile 'com.google.android:support-v4:r7'
     testCompile 'com.google.testing.compile:compile-testing:0.6'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -182,7 +182,8 @@ public class DeepLinkProcessor extends AbstractProcessor {
       .beginControlFlow("if (isError)")
       .addStatement("intent.putExtra(DeepLinkActivity.EXTRA_ERROR_MESSAGE, errorMessage)")
       .endControlFlow()
-      .addStatement("sendBroadcast(intent)")
+      .addStatement("$T.getInstance(this).sendBroadcast(intent)",
+          ClassName.get("android.support.v4.content", "LocalBroadcastManager"))
       .build();
 
 

--- a/deeplinkdispatch-processor/src/test/resources/DeepLinkActivity.java
+++ b/deeplinkdispatch-processor/src/test/resources/DeepLinkActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 import java.lang.Override;
 import java.lang.String;
@@ -91,7 +92,7 @@ public class DeepLinkActivity extends Activity {
     if (isError) {
       intent.putExtra(DeepLinkActivity.EXTRA_ERROR_MESSAGE, errorMessage);
     }
-    sendBroadcast(intent);
+    LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
   }
 }
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.airbnb.deeplinkdispatch.sample" >
 
     <application
+        android:name=".SampleApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -27,14 +28,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="airbnb" />
                 <data android:scheme="http" />
-
             </intent-filter>
         </activity>
-        <receiver android:name=".DeepLinkReceiver" >
-            <intent-filter>
-                <action android:name="com.airbnb.deeplinkdispatch.DEEPLINK_ACTION" />
-            </intent-filter>
-        </receiver>
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/SampleApplication.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/SampleApplication.java
@@ -1,0 +1,14 @@
+package com.airbnb.deeplinkdispatch.sample;
+
+import android.app.Application;
+import android.content.IntentFilter;
+import android.support.v4.content.LocalBroadcastManager;
+
+public class SampleApplication extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    IntentFilter intentFilter = new IntentFilter("com.airbnb.deeplinkdispatch.DEEPLINK_ACTION");
+    LocalBroadcastManager.getInstance(this).registerReceiver(new DeepLinkReceiver(), intentFilter);
+  }
+}


### PR DESCRIPTION
By using a ``LocalBroadcastManager`` instead of sending a global intent solves the issue (https://github.com/airbnb/DeepLinkDispatch/issues/55) that not any other app can respond to the broadcast.