### PR TITLE
Fixed scheme setter in DeepLinkUri Builder.

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
@@ -444,9 +444,8 @@ final class DeepLinkUri {
     }
 
     Builder scheme(String scheme) {
-      if (scheme == null) {
-        throw new IllegalArgumentException("scheme == null");
-      }
+      if (scheme == null) throw new IllegalArgumentException("scheme == null");
+      this.scheme = scheme;
       return this;
     }
 


### PR DESCRIPTION
The changes done to HttpUrl class missed out setting the scheme in Builder.