### PR TITLE
Get a query parameter that contains the brackets

### DIFF
--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -198,15 +198,19 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .addStatement("$T uri = getIntent().getData()", ClassName.get("android.net", "Uri"))
         .addStatement("String uriString = uri.toString()")
         .addStatement("DeepLinkEntry entry = registry.parseUri(uriString)")
+        .addStatement("DeepLinkUri deepLinkUri = DeepLinkUri.parse(uriString)")
         .beginControlFlow("if (entry != null)")
         .addStatement("$T<String, String> parameterMap = entry.getParameters(uriString)", Map.class)
-        .beginControlFlow("for (String queryParameter : uri.getQueryParameterNames())")
+        .beginControlFlow("for (String queryParameter : deepLinkUri.queryParameterNames())")
+        .beginControlFlow(
+            "for (String queryParameterValue : deepLinkUri.queryParameterValues(queryParameter))")
         .beginControlFlow("if (parameterMap.containsKey(queryParameter))")
         .addStatement(
             "$T.w(TAG, \"Duplicate parameter name in path and query param: \" + queryParameter)",
             ClassName.get("android.util", "Log"))
         .endControlFlow()
-        .addStatement("parameterMap.put(queryParameter, uri.getQueryParameter(queryParameter))")
+        .addStatement("parameterMap.put(queryParameter, queryParameterValue)")
+        .endControlFlow()
         .endControlFlow()
         .addStatement("parameterMap.put(DeepLink.URI, uri.toString())")
         .beginControlFlow("try")

--- a/deeplinkdispatch-processor/src/test/resources/DeepLinkActivity.java
+++ b/deeplinkdispatch-processor/src/test/resources/DeepLinkActivity.java
@@ -32,13 +32,16 @@ public class DeepLinkActivity extends Activity {
     Uri uri = getIntent().getData();
     String uriString = uri.toString();
     DeepLinkEntry entry = registry.parseUri(uriString);
+    DeepLinkUri deepLinkUri = DeepLinkUri.parse(uriString);
     if (entry != null) {
       Map<String, String> parameterMap = entry.getParameters(uriString);
-      for (String queryParameter : uri.getQueryParameterNames()) {
-        if (parameterMap.containsKey(queryParameter)) {
-          Log.w(TAG, "Duplicate parameter name in path and query param: " + queryParameter);
+      for (String queryParameter : deepLinkUri.queryParameterNames()) {
+        for (String queryParameterValue : deepLinkUri.queryParameterValues(queryParameter)) {
+          if (parameterMap.containsKey(queryParameter)) {
+            Log.w(TAG, "Duplicate parameter name in path and query param: " + queryParameter);
+          }
+          parameterMap.put(queryParameter, queryParameterValue);
         }
-        parameterMap.put(queryParameter, uri.getQueryParameter(queryParameter));
       }
       parameterMap.put(DeepLink.URI, uri.toString());
       try {

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
@@ -69,6 +69,21 @@ public class MainActivityTest {
     assertThat(launchedIntent.getStringExtra(DeepLink.URI),
         equalTo("airbnb://classDeepLink?foo=bar"));
   }
+ @Test public void testQueryParamsWithBracket() {
+     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("airbnb://classDeepLink?foo[max]=123"));
+     DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
+             .withIntent(intent).create().get();
+     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
+
+     Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
+     assertThat(launchedIntent.getComponent(),
+             equalTo(new ComponentName(deepLinkActivity, MainActivity.class)));
+
+     assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+     assertThat(launchedIntent.getStringExtra("foo[max]"), equalTo("123"));
+     assertThat(launchedIntent.getStringExtra(DeepLink.URI),
+             equalTo("airbnb://classDeepLink?foo[max]=123"));
+ }
 
   @Test public void testHttpScheme() {
     Intent intent = new Intent(Intent.ACTION_VIEW,


### PR DESCRIPTION
Thank you for this great library!


I could not get a query parameter that contains the brackets.

For example,
```
airbnb://foo/baz?marsh[max]=mallow
```

`marsh[max]` is null.


The reason for this, please refer to the following.

https://github.com/airbnb/DeepLinkDispatch/blob/759cd16/deeplinkdispatch-processor/src/test/resources/DeepLinkActivity.java#L41

sample
```
import android.net.Uri;

String urlString = "airbnb://foo/baz?marsh[max]=mallow";
Uri uri = Uri.parse(urlString);

uri.getQueryParameter("marsh[max]");  // null

uri.getQueryParameterNames(); // can get key(marsh[max])
```

`android.net.Uri` package can not get a query parameter that contains the brackets.


For this reason, I have sent a pull request.

Thank you.
