### PR TITLE
a parameter should not contain a forward slash, corrected param value regex

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -24,7 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 final class DeepLinkEntry {
-  private static final String PARAM_VALUE = "([a-zA-Z0-9_#!+%-~,\\.\\$]*)";
+  private static final String PARAM_VALUE = "([a-zA-Z0-9_#!+%~,\\-\\.\\$]*)";
   private static final String PARAM = "([a-zA-Z][a-zA-Z0-9_-]*)";
   private static final String PARAM_REGEX = "%7B(" + PARAM + ")%7D";
 

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -43,6 +43,13 @@ public class DeepLinkEntryTest {
     assertThat(parameters.get("param1")).isEqualTo("N1.55,22.11");
   }
 
+  @Test public void testParamWithSlash() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}");
+
+    Map<String, String> parameters = entry.getParameters("airbnb://test/123/foo");
+    assertThat(parameters).isEmpty();
+  }
+
   @Test public void testNoMatchesFound() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
 


### PR DESCRIPTION
See #61 for more detail about the issue.

The problem was is the regex `%-~` means "any character from % to ~". What we want is an exact match to `-` so `\\-` works better.