### PR TITLE
Update readme on static method deeplinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ public class MainActivity extends Activity {
 
 ### Method Annotations
 
-You can also annotate static methods that return an `Intent`. `DeepLinkDispatch` will call that
+You can also annotate static methods that take a `Context` and return an `Intent`. `DeepLinkDispatch` will call that
 method to create that `Intent` and use it when starting your activity via that registered deep link:
 
 ```java


### PR DESCRIPTION
Update readme to explicitly declare that a static method must only receive one Context argument.

Originally I tried to use a method with more than one argument, and took a lot of debugging through error messages, to realize that it's because it needs exactly one Context.