### PR TITLE
Renames

### DIFF
--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -72,7 +72,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
     return new HashSet<>(
         Arrays.asList(
             DeepLink.class.getCanonicalName(),
-            DeepLinkActivity.class.getCanonicalName()));
+            DeepLinkHandler.class.getCanonicalName()));
   }
 
   @Override public SourceVersion getSupportedSourceVersion() {
@@ -112,7 +112,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
     }
 
     boolean hasSpecifiedDeepLinkActivity
-        = !roundEnv.getElementsAnnotatedWith(DeepLinkActivity.class).isEmpty();
+        = !roundEnv.getElementsAnnotatedWith(DeepLinkHandler.class).isEmpty();
 
     if (!deepLinkElements.isEmpty()) {
       try {
@@ -280,12 +280,12 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .addParameter(ClassName.get("android.net", "Uri"), "uri")
         .addParameter(String.class, "errorMessage")
         .addStatement("$T intent = new Intent()", ANDROID_INTENT)
-        .addStatement("intent.setAction($T.ACTION)", DeepLinkActivity.class)
-        .addStatement("intent.putExtra($T.EXTRA_URI, uri.toString())", DeepLinkActivity.class)
-        .addStatement("intent.putExtra($T.EXTRA_SUCCESSFUL, !isError)", DeepLinkActivity.class)
+        .addStatement("intent.setAction($T.ACTION)", DeepLinkHandler.class)
+        .addStatement("intent.putExtra($T.EXTRA_URI, uri.toString())", DeepLinkHandler.class)
+        .addStatement("intent.putExtra($T.EXTRA_SUCCESSFUL, !isError)", DeepLinkHandler.class)
         .beginControlFlow("if (isError)")
         .addStatement("intent.putExtra($T.EXTRA_ERROR_MESSAGE, errorMessage)",
-                DeepLinkActivity.class)
+                DeepLinkHandler.class)
         .endControlFlow()
         .addStatement("$T.getInstance(context).sendBroadcast(intent)",
             ClassName.get("android.support.v4.content", "LocalBroadcastManager"))
@@ -397,7 +397,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .endControlFlow()
         .build();
 
-    TypeSpec deepLinkActivity = TypeSpec.classBuilder("DeepLinkDelegate")
+    TypeSpec deepLinkDelegate = TypeSpec.classBuilder("DeepLinkDelegate")
         .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
         .addField(tag)
         .addMethod(constructor)
@@ -406,7 +406,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .addMethod(notifyListenerMethod)
         .build();
 
-    JavaFile.builder("com.airbnb.deeplinkdispatch", deepLinkActivity)
+    JavaFile.builder("com.airbnb.deeplinkdispatch", deepLinkDelegate)
         .build()
         .writeTo(filer);
   }
@@ -422,7 +422,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
             ClassName.get("com.airbnb.deeplinkdispatch", "DeepLinkDelegate"))
         .build();
 
-    TypeSpec deepLinkActivity = TypeSpec.classBuilder("DeepLinkDispatchActivity")
+    TypeSpec deepLinkActivity = TypeSpec.classBuilder("DeepLinkActivity")
         .addModifiers(Modifier.PUBLIC)
         .superclass(ClassName.get("android.app", "Activity"))
         .addMethod(onCreateMethod)

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorTest.java
@@ -22,7 +22,7 @@ public class DeepLinkProcessorTest {
         .compilesWithoutError()
         .and()
         .generatesSources(
-            JavaFileObjects.forResource("DeepLinkDispatchActivity.java"),
+            JavaFileObjects.forResource("DeepLinkActivity.java"),
             JavaFileObjects.forSourceString("DeepLinkLoader.java",
                 "package com.airbnb.deeplinkdispatch;\n"
                     + "\n"
@@ -62,7 +62,7 @@ public class DeepLinkProcessorTest {
         .compilesWithoutError()
         .and()
         .generatesSources(
-            JavaFileObjects.forResource("DeepLinkDispatchActivity.java"),
+            JavaFileObjects.forResource("DeepLinkActivity.java"),
             JavaFileObjects.forSourceString("DeepLinkLoader.java",
                 "package com.airbnb.deeplinkdispatch;\n"
                     + "\n"

--- a/deeplinkdispatch-processor/src/test/resources/DeepLinkActivity.java
+++ b/deeplinkdispatch-processor/src/test/resources/DeepLinkActivity.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.os.Bundle;
 import java.lang.Override;
 
-public class DeepLinkDispatchActivity extends Activity {
+public class DeepLinkActivity extends Activity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);

--- a/deeplinkdispatch-processor/src/test/resources/DeepLinkDelegate.java
+++ b/deeplinkdispatch-processor/src/test/resources/DeepLinkDelegate.java
@@ -97,11 +97,11 @@ public final class DeepLinkDelegate {
 
   private static void notifyListener(Context context, boolean isError, Uri uri, String errorMessage) {
     Intent intent = new Intent();
-    intent.setAction(DeepLinkActivity.ACTION);
-    intent.putExtra(DeepLinkActivity.EXTRA_URI, uri.toString());
-    intent.putExtra(DeepLinkActivity.EXTRA_SUCCESSFUL, !isError);
+    intent.setAction(DeepLinkHandler.ACTION);
+    intent.putExtra(DeepLinkHandler.EXTRA_URI, uri.toString());
+    intent.putExtra(DeepLinkHandler.EXTRA_SUCCESSFUL, !isError);
     if (isError) {
-      intent.putExtra(DeepLinkActivity.EXTRA_ERROR_MESSAGE, errorMessage);
+      intent.putExtra(DeepLinkHandler.EXTRA_ERROR_MESSAGE, errorMessage);
     }
     LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
   }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkHandler.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkHandler.java
@@ -21,12 +21,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that this activity will receive deep links, so the processor knows not to generate
- * a separate activity.
+ * Indicates that this a given type will receive deep links and handle them, so the processor
+ * knows not to generate a separate activity.
  */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS)
-public @interface DeepLinkActivity {
+public @interface DeepLinkHandler {
     String ACTION = "com.airbnb.deeplinkdispatch.DEEPLINK_ACTION";
     String EXTRA_SUCCESSFUL = "com.airbnb.deeplinkdispatch.EXTRA_SUCCESSFUL";
     String EXTRA_URI = "com.airbnb.deeplinkdispatch.EXTRA_URI";

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
             android:label="@string/title_second"
             />
         <activity
-            android:name="com.airbnb.deeplinkdispatch.DeepLinkDispatchActivity"
+            android:name="com.airbnb.deeplinkdispatch.DeepLinkActivity"
             android:theme="@android:style/Theme.NoDisplay">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/DeepLinkReceiver.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/DeepLinkReceiver.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-import com.airbnb.deeplinkdispatch.DeepLinkActivity;
+import com.airbnb.deeplinkdispatch.DeepLinkHandler;
 
 
 public class DeepLinkReceiver extends BroadcastReceiver {
@@ -13,12 +13,12 @@ public class DeepLinkReceiver extends BroadcastReceiver {
 
   @Override
   public void onReceive(Context context, Intent intent) {
-    String deepLinkUri = intent.getStringExtra(DeepLinkActivity.EXTRA_URI);
+    String deepLinkUri = intent.getStringExtra(DeepLinkHandler.EXTRA_URI);
 
-    if (intent.getBooleanExtra(DeepLinkActivity.EXTRA_SUCCESSFUL, false)) {
+    if (intent.getBooleanExtra(DeepLinkHandler.EXTRA_SUCCESSFUL, false)) {
       Log.i(TAG, "Success deep linking: " + deepLinkUri);
     } else {
-      String errorMessage = intent.getStringExtra(DeepLinkActivity.EXTRA_ERROR_MESSAGE);
+      String errorMessage = intent.getStringExtra(DeepLinkHandler.EXTRA_ERROR_MESSAGE);
       Log.e(TAG, "Error deep linking: " + deepLinkUri + " with error message +" + errorMessage);
     }
   }

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/SampleApplication.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/SampleApplication.java
@@ -4,13 +4,12 @@ import android.app.Application;
 import android.content.IntentFilter;
 import android.support.v4.content.LocalBroadcastManager;
 
-import com.airbnb.deeplinkdispatch.DeepLink;
-import com.airbnb.deeplinkdispatch.DeepLinkActivity;
+import com.airbnb.deeplinkdispatch.DeepLinkHandler;
 
 public class SampleApplication extends Application {
   @Override public void onCreate() {
     super.onCreate();
-    IntentFilter intentFilter = new IntentFilter(DeepLinkActivity.ACTION);
+    IntentFilter intentFilter = new IntentFilter(DeepLinkHandler.ACTION);
     LocalBroadcastManager.getInstance(this).registerReceiver(new DeepLinkReceiver(), intentFilter);
   }
 }

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 import android.net.Uri;
 
 import com.airbnb.deeplinkdispatch.DeepLink;
-import com.airbnb.deeplinkdispatch.DeepLinkDispatchActivity;
+import com.airbnb.deeplinkdispatch.DeepLinkActivity;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +23,7 @@ import static org.robolectric.Shadows.shadowOf;
 public class MainActivityTest {
   @Test public void testIntent() {
     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://host/somePath/1234321"));
-    DeepLinkDispatchActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkDispatchActivity.class)
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
         .withIntent(intent).create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 
@@ -40,7 +40,7 @@ public class MainActivityTest {
 
   @Test public void testQueryParams() {
     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://classDeepLink?foo=bar"));
-    DeepLinkDispatchActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkDispatchActivity.class)
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
         .withIntent(intent).create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 
@@ -57,7 +57,7 @@ public class MainActivityTest {
   @Test public void testQueryParamsWithBracket() {
     Intent intent =
         new Intent(Intent.ACTION_VIEW, Uri.parse("dld://classDeepLink?foo[max]=123"));
-    DeepLinkDispatchActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkDispatchActivity.class)
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
         .withIntent(intent).create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 
@@ -74,7 +74,7 @@ public class MainActivityTest {
   @Test public void testHttpScheme() {
     Intent intent = new Intent(Intent.ACTION_VIEW,
         Uri.parse("http://example.com/fooball?baz=something"));
-    DeepLinkDispatchActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkDispatchActivity.class)
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
         .withIntent(intent).create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/SecondActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/SecondActivityTest.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 import android.net.Uri;
 
 import com.airbnb.deeplinkdispatch.DeepLink;
-import com.airbnb.deeplinkdispatch.DeepLinkDispatchActivity;
+import com.airbnb.deeplinkdispatch.DeepLinkActivity;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,7 +25,7 @@ public class SecondActivityTest {
     public void testIntent() {
         Intent intent = new Intent(Intent.ACTION_VIEW,
                                    Uri.parse("http://example.com/deepLink/123/myname"));
-        DeepLinkDispatchActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkDispatchActivity.class)
+        DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
             .withIntent(intent).create().get();
         ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 


### PR DESCRIPTION
#### Rename DeepLinkActivity -> DeepLinkHandler
  - More generic naming so it doesn't look weird to have it on non-activities (fragments, controllers, wherever)

#### Rename DeepLinkDispatchActivity -> DeepLinkActivity
  - Preserves compatibility for anyone that used it before and means they don't have to update names if they want to keep it.