### PR TITLE
Require a non-zero length param value

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -24,7 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 final class DeepLinkEntry {
-  private static final String PARAM_VALUE = "([a-zA-Z0-9_#'!+%~,\\-\\.\\@\\$]*)";
+  private static final String PARAM_VALUE = "([a-zA-Z0-9_#'!+%~,\\-\\.\\@\\$]+)";
   private static final String PARAM = "([a-zA-Z][a-zA-Z0-9_-]*)";
   private static final String PARAM_REGEX = "%7B(" + PARAM + ")%7D";
 

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -64,6 +64,22 @@ public class DeepLinkEntryTest {
     assertThat(entry.getParameters("airbnb://test.com").isEmpty()).isTrue();
   }
 
+  @Test
+  public void testEmptyParametersDontMatch() throws Exception {
+    DeepLinkEntry entry = deepLinkEntry("dld://foo/{id}/bar");
+
+    assertThat(entry.matches("dld://foo//bar")).isFalse();
+  }
+
+  @Test
+  public void testEmptyPathPresentParams() throws Exception {
+    DeepLinkEntry entry = deepLinkEntry("dld://foo/{id}");
+    DeepLinkEntry entryNoParam = deepLinkEntry("dld://foo");
+
+    assertThat(entry.matches("dld://foo")).isFalse();
+    assertThat(entryNoParam.matches("dld://foo")).isTrue();
+  }
+
   @Test public void testWithQueryParam() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://something");
 


### PR DESCRIPTION
Right now (and I believe as of 1.5.0), we're seeing a bug where `DeepLinkEntry` matches against Uris with empty params improperly.

For instance - If you have:

```
dld://foo
dld://foo/{id}
```

You'll find that the second URI is matched - with an empty id, rather than matching the first path. Additionally, you'll see that routes like `dld://foo/{id}/bar` are incorrectly matching against things like `dld://foo//bar`. Changing the Regex operator to require a character match would fix these two issues.

Also, for an added bonus - I think the first case is obscured based on the order that the entries are listed in the Loader - which is based on the name of the Activity. 