### PR TITLE
Fix for #104

### DIFF
--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -280,7 +280,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .addParameter(String.class, "errorMessage")
         .addStatement("$T intent = new Intent()", ANDROID_INTENT)
         .addStatement("intent.setAction($T.ACTION)", DeepLinkHandler.class)
-        .addStatement("intent.putExtra($T.EXTRA_URI, uri.toString())", DeepLinkHandler.class)
+        .addStatement("intent.putExtra($T.EXTRA_URI, uri != null ? uri.toString() : $S)", DeepLinkHandler.class, "")
         .addStatement("intent.putExtra($T.EXTRA_SUCCESSFUL, !isError)", DeepLinkHandler.class)
         .beginControlFlow("if (isError)")
         .addStatement("intent.putExtra($T.EXTRA_ERROR_MESSAGE, errorMessage)",

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -280,7 +280,8 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .addParameter(String.class, "errorMessage")
         .addStatement("$T intent = new Intent()", ANDROID_INTENT)
         .addStatement("intent.setAction($T.ACTION)", DeepLinkHandler.class)
-        .addStatement("intent.putExtra($T.EXTRA_URI, uri != null ? uri.toString() : $S)", DeepLinkHandler.class, "")
+        .addStatement("intent.putExtra($T.EXTRA_URI, uri != null ? uri.toString() : $S)",
+                DeepLinkHandler.class, "")
         .addStatement("intent.putExtra($T.EXTRA_SUCCESSFUL, !isError)", DeepLinkHandler.class)
         .beginControlFlow("if (isError)")
         .addStatement("intent.putExtra($T.EXTRA_ERROR_MESSAGE, errorMessage)",


### PR DESCRIPTION
Fix for a NullPointerExeception when sending through an activity with no data.

When using DeeplinkDelegate on an activity that is launched through the launcher it will create a NPE as the activity doesn't have data.