### PR TITLE
Adding singleTop support

### DIFF
--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -320,7 +320,20 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .beginControlFlow("if (activity == null)")
         .addStatement("throw new $T($S)", NullPointerException.class, "activity == null")
         .endControlFlow()
-        .addStatement("$T sourceIntent = activity.getIntent()", ANDROID_INTENT)
+        .addStatement("return dispatchFrom(activity, activity.getIntent())")
+        .build();
+
+    MethodSpec dispatchFromMethodWithIntent = MethodSpec.methodBuilder("dispatchFrom")
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .returns(DEEPLINKRESULT)
+        .addParameter(ClassName.get("android.app", "Activity"), "activity")
+        .addParameter(ClassName.get("android.content", "Intent"), "sourceIntent")
+        .beginControlFlow("if (activity == null)")
+        .addStatement("throw new $T($S)", NullPointerException.class, "activity == null")
+        .endControlFlow()
+        .beginControlFlow("if (sourceIntent == null)")
+        .addStatement("throw new $T($S)", NullPointerException.class, "sourceIntent == null")
+        .endControlFlow()
         .addStatement("$T uri = sourceIntent.getData()", ANDROID_URI)
         .beginControlFlow("if (uri == null)")
         .addStatement("return createResultAndNotify(activity, false, null, $S)",
@@ -402,6 +415,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .addField(tag)
         .addMethod(constructor)
         .addMethod(dispatchFromMethod)
+        .addMethod(dispatchFromMethodWithIntent)
         .addMethod(createResultAndNotifyMethod)
         .addMethod(notifyListenerMethod)
         .build();

--- a/deeplinkdispatch-processor/src/test/resources/DeepLinkDelegate.java
+++ b/deeplinkdispatch-processor/src/test/resources/DeepLinkDelegate.java
@@ -25,7 +25,16 @@ public final class DeepLinkDelegate {
     if (activity == null) {
       throw new NullPointerException("activity == null");
     }
-    Intent sourceIntent = activity.getIntent();
+    return dispatchFrom(activity, activity.getIntent());
+  }
+
+  public static com.airbnb.deeplinkdispatch.DeepLinkResult dispatchFrom(Activity activity, Intent sourceIntent) {
+    if (activity == null) {
+      throw new NullPointerException("activity == null");
+    }
+    if (sourceIntent == null) {
+      throw new NullPointerException("sourceIntent == null");
+    }
     Uri uri = sourceIntent.getData();
     if (uri == null) {
       return createResultAndNotify(activity, false, null, "No Uri in given activity's intent.");
@@ -98,7 +107,7 @@ public final class DeepLinkDelegate {
   private static void notifyListener(Context context, boolean isError, Uri uri, String errorMessage) {
     Intent intent = new Intent();
     intent.setAction(DeepLinkHandler.ACTION);
-    intent.putExtra(DeepLinkHandler.EXTRA_URI, uri.toString());
+    intent.putExtra(DeepLinkHandler.EXTRA_URI, uri != null ? uri.toString() : "");
     intent.putExtra(DeepLinkHandler.EXTRA_SUCCESSFUL, !isError);
     if (isError) {
       intent.putExtra(DeepLinkHandler.EXTRA_ERROR_MESSAGE, errorMessage);


### PR DESCRIPTION
A singleTop activity doesn't get deeplink info through `getIntent()` on the activity. Instead it gets it from a call on `onNewIntent(Intent intent)` and that intent must be handed to DeeplinkDelegate. Here I overloaded the `dispatchFrom` method to support handing through both the activity and the intent that should be used.