### PR TITLE
Upgrade gradle:2.3.0-beta2 → 2.3.0-rc1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+    classpath 'com.android.tools.build:gradle:2.3.0-rc1'
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   }
 }


### PR DESCRIPTION
The current `2.3.0-beta2` version gives the following error:

> Error:(1, 0) The android gradle plugin version 2.3.0-beta2 is too old, please update to the latest version.
