### PR TITLE
Fix TAG declarations in sample activities

### DIFF
--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivity.java
@@ -13,7 +13,7 @@ import com.airbnb.deeplinkdispatch.sample.library.LibraryDeepLink;
 @WebDeepLink({ "/users", "/user/{id}" })
 @LibraryDeepLink({ "/library_deeplink", "/library_deeplink/{lib_id}" })
 public class CustomPrefixesActivity extends AppCompatActivity {
-  private static final String TAG = SecondActivity.class.getSimpleName();
+  private static final String TAG = CustomPrefixesActivity.class.getSimpleName();
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
@@ -31,7 +31,7 @@ import com.airbnb.deeplinkdispatch.DeepLink;
 public class MainActivity extends AppCompatActivity {
   private static final String ACTION_DEEP_LINK_METHOD = "deep_link_method";
   private static final String ACTION_DEEP_LINK_COMPLEX = "deep_link_complex";
-  private static final String TAG = SecondActivity.class.getSimpleName();
+  private static final String TAG = MainActivity.class.getSimpleName();
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/SecondActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/SecondActivity.java
@@ -12,7 +12,7 @@ import com.airbnb.deeplinkdispatch.DeepLink;
 @DeepLink("http://example.com/deepLink/{id}/{name}")
 public class SecondActivity extends AppCompatActivity {
 
-  private String TAG = SecondActivity.class.getSimpleName();
+  private static final String TAG = SecondActivity.class.getSimpleName();
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
`TAG` constant used by log should be `static final`, and be the same as the class's simple name.