### PR TITLE
update Annotations with a lower retention.

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLink.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLink.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * </code></pre>
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 public @interface DeepLink {
   String IS_DEEP_LINK = "is_deep_link_flag";
   String URI = "deep_link_uri";

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkHandler.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkHandler.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * incoming {@code Intent} to the correct Activities annotated with {@link DeepLink}.
  */
 @Target({ ElementType.TYPE })
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 public @interface DeepLinkHandler {
   /**
    * A list of {@link DeepLinkModule} annotated classes used for collecting all the deep links in

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkModule.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkModule.java
@@ -16,6 +16,6 @@ import java.lang.annotation.Target;
  * Intent delivery.
  */
 @Target({ ElementType.TYPE })
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 public @interface DeepLinkModule {
 }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkSpec.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkSpec.java
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
  * </ul>
  */
 @Target({ ElementType.ANNOTATION_TYPE })
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 public @interface DeepLinkSpec {
   String[] prefix();
 }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkSpec.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkSpec.java
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
  * </ul>
  */
 @Target({ ElementType.ANNOTATION_TYPE })
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface DeepLinkSpec {
   String[] prefix();
 }


### PR DESCRIPTION
Annotation with CLASS retention will be recorded in compiled `.class` file, which is not necessary for DeepLink. 

Besides, in this condition, the Android assemble task will fail when the ProgGuard is enabled because the the annotation class may be reversed by ProGuard. The annotation info recorded in class file will not match the reserved annotation class. Check out the following message.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:transformClassesWithMultidexlistForRelease'.
> java.lang.UnsupportedOperationException (no error message)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```