### PR TITLE
Add custom annotation Proguard reminder to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ Snapshots of the development version are available in
      @com.airbnb.deeplinkdispatch.DeepLink <methods>;
 }
 ```
+**Note:** remember to include Proguard rules to keep Custom annotations you have used, for example by package:
+
+```
+-keep @interface your.package.path.deeplink.** { *; }
+-keepclasseswithmembers class * {
+    @your.package.path.deeplink.* <methods>;
+}
+```
 
 ## Testing the sample app
 


### PR DESCRIPTION
Added README reminder to configure Proguard rules when using Custom annotations. 

The rules in my example are not perfect. Instead I would like to keep annotations that themselves are annotated by `DeepLinkSpec` and then clients of those annotations, but I don't know Proguard enough to handle such scenario.

If you want, I can also use an example that would specifically keep `AppDeepLink` and `WebDeepLink`, but that would be more verbose.