### PR TITLE
Workaround for #160

### DIFF
--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -258,14 +258,9 @@ public class DeepLinkProcessor extends AbstractProcessor {
           if (uri1.queryParameterNames().size() != uri2.queryParameterNames().size()) {
             return uri2.queryParameterNames().size() - uri1.queryParameterNames().size();
           } else {
-            if (!uri1.encodedPath().contains("%7B") && uri2.encodedPath().contains("%7B")) {
-              return -1;
-            } else if (uri1.encodedPath().contains("%7B") && !uri2.encodedPath().contains("%7B")) {
-              return 1;
-            }
+            return uri1.encodedPath().split("%7B").length - uri2.encodedPath().split("%7B").length;
           }
         }
-        return 0;
       }
     });
     for (int i = 0; i < totalElements; i++) {

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -257,11 +257,9 @@ public class DeepLinkProcessor extends AbstractProcessor {
           if (uri1.queryParameterNames().size() != uri2.queryParameterNames().size()) {
             return uri2.queryParameterNames().size() - uri1.queryParameterNames().size();
           } else {
-            if (uri1.encodedPath().contains("{") && uri2.encodedPath().contains("{")) {
-              return uri2.pathSegments().size() - uri1.pathSegments().size();
-            } else if (!uri1.encodedPath().contains("{") && uri2.encodedPath().contains("{")) {
+            if (!uri1.encodedPath().contains("%7B") && uri2.encodedPath().contains("%7B")) {
               return -1;
-            } else if (uri1.encodedPath().contains("{") && !uri2.encodedPath().contains("{")) {
+            } else if (uri1.encodedPath().contains("%7B") && !uri2.encodedPath().contains("%7B")) {
               return 1;
             }
           }

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -42,6 +42,7 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -246,6 +247,28 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .add("$T.unmodifiableList($T.asList(\n", CLASS_COLLECTIONS, CLASS_ARRAYS)
         .indent();
     int totalElements = elements.size();
+    Collections.sort(elements, new Comparator<DeepLinkAnnotatedElement>() {
+      @Override public int compare(DeepLinkAnnotatedElement element1, DeepLinkAnnotatedElement element2) {
+        DeepLinkUri uri1 = DeepLinkUri.parse(element1.getUri());
+        DeepLinkUri uri2 = DeepLinkUri.parse(element2.getUri());
+        if (uri1.pathSegments().size() != uri2.pathSegments().size()) {
+          return uri2.pathSegments().size() - uri1.pathSegments().size();
+        } else {
+          if (uri1.queryParameterNames().size() != uri2.queryParameterNames().size()) {
+            return uri2.queryParameterNames().size() - uri1.queryParameterNames().size();
+          } else {
+            if (uri1.encodedPath().contains("{") && uri2.encodedPath().contains("{")) {
+              return uri2.pathSegments().size() - uri1.pathSegments().size();
+            } else if (!uri1.encodedPath().contains("{") && uri2.encodedPath().contains("{")) {
+              return -1;
+            } else if (uri1.encodedPath().contains("{") && !uri2.encodedPath().contains("{")) {
+              return 1;
+            }
+          }
+        }
+        return 0;
+      }
+    });
     for (int i = 0; i < totalElements; i++) {
       DeepLinkAnnotatedElement element = elements.get(i);
       String type = "DeepLinkEntry.Type." + element.getAnnotationType().toString();

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -248,7 +248,8 @@ public class DeepLinkProcessor extends AbstractProcessor {
         .indent();
     int totalElements = elements.size();
     Collections.sort(elements, new Comparator<DeepLinkAnnotatedElement>() {
-      @Override public int compare(DeepLinkAnnotatedElement element1, DeepLinkAnnotatedElement element2) {
+      @Override
+      public int compare(DeepLinkAnnotatedElement element1, DeepLinkAnnotatedElement element2) {
         DeepLinkUri uri1 = DeepLinkUri.parse(element1.getUri());
         DeepLinkUri uri2 = DeepLinkUri.parse(element2.getUri());
         if (uri1.pathSegments().size() != uri2.pathSegments().size()) {

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorTest.java
@@ -270,4 +270,94 @@ public class DeepLinkProcessorTest {
         .failsToCompile()
         .withErrorContaining("Prefix property cannot be empty");
   }
+
+  @Test public void testProcessorWithDeepLinkSortRule() {
+    JavaFileObject sampleActivity = JavaFileObjects
+        .forSourceString("SampleActivity", "package com.example;"
+            + "import android.content.Context;\n"
+            + "import android.content.Intent;\n"
+            + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+            + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n"
+            + "import com.example.SampleModule;\n\n"
+            + "@DeepLinkHandler({ SampleModule.class })\n"
+            + "public class SampleActivity {\n"
+            + "  @DeepLink(\"airbnb://host/{var}\")"
+            + "  public static Intent intentFromOnePathWithOneParam(Context context){"
+            + "    return new Intent();"
+            + "  }"
+            + "  @DeepLink(\"airbnb://host/path\")"
+            + "  public static Intent intentFromOnePath(Context context){"
+            + "    return new Intent();"
+            + "  }"
+            + "  @DeepLink(\"airbnb://host/path1/path2\")"
+            + "  public static Intent intentFromTwoPath(Context context){"
+            + "    return new Intent();"
+            + "  }"
+            + "  @DeepLink(\"airbnb://host/path1/path2?q={q}\")"
+            + "  public static Intent intentFromTwoPathWithQuery(Context context){"
+            + "    return new Intent();"
+            + "  }"
+            + "  @DeepLink(\"airbnb://host/{var1}/{var2}\")"
+            + "  public static Intent intentFromTwoPathWithTwoParams(Context context){"
+            + "    return new Intent();"
+            + "  }"
+            + "}"
+        );
+
+    JavaFileObject module = JavaFileObjects.forSourceString(
+        "SampleModule", "package com.example;"
+            + "import com.airbnb.deeplinkdispatch.DeepLinkModule;\n\n"
+            + "@DeepLinkModule\n"
+            + "public class SampleModule {\n"
+            + "}");
+
+    assertAbout(javaSources())
+        .that(Arrays.asList(module, sampleActivity))
+        .processedWith(new DeepLinkProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(
+            JavaFileObjects.forResource("DeepLinkDelegate.java"),
+            JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleLoader",
+                "package com.example;\n"
+                    + "\n"
+                    + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
+                    + "import com.airbnb.deeplinkdispatch.Parser;\n"
+                    + "import java.lang.Override;\n"
+                    + "import java.lang.String;\n"
+                    + "import java.util.Arrays;\n"
+                    + "import java.util.Collections;\n"
+                    + "import java.util.List;\n"
+                    + "\n"
+                    + "public final class SampleModuleLoader implements Parser {\n"
+                    + "public static final List<DeepLinkEntry> REGISTRY ="
+                    + " Collections.unmodifiableList(Arrays.asList(\n"
+                    + "    new DeepLinkEntry(\"airbnb://host/path1/path2?q={q}\","
+                    + " DeepLinkEntry.Type.METHOD, SampleActivity.class,"
+                    + " \"intentFromTwoPathWithQuery\"),\n"
+                    + "    new DeepLinkEntry(\"airbnb://host/path1/path2\","
+                    + " DeepLinkEntry.Type.METHOD, SampleActivity.class,"
+                    + " \"intentFromTwoPath\"),\n"
+                    + "    new DeepLinkEntry(\"airbnb://host/{var1}/{var2}\","
+                    + " DeepLinkEntry.Type.METHOD, SampleActivity.class,"
+                    + " \"intentFromTwoPathWithTwoParams\"),\n"
+                    + "    new DeepLinkEntry(\"airbnb://host/path\","
+                    + " DeepLinkEntry.Type.METHOD, SampleActivity.class,"
+                    + " \"intentFromOnePath\"),\n"
+                    + "    new DeepLinkEntry(\"airbnb://host/{var}\","
+                    + " DeepLinkEntry.Type.METHOD, SampleActivity.class,"
+                    + " \"intentFromOnePathWithOneParam\")\n"
+                    + "  ));\n"
+                    + "\n"
+                    + "  @Override\n"
+                    + "  public DeepLinkEntry parseUri(String uri) {\n"
+                    + "    for (DeepLinkEntry entry : REGISTRY) {\n"
+                    + "      if (entry.matches(uri)) {\n"
+                    + "        return entry;\n"
+                    + "      }\n"
+                    + "    }\n"
+                    + "    return null;\n"
+                    + "  }"
+                    + "}"));
+  }
 }


### PR DESCRIPTION
Sort the elements with url to make the case of #160 workaround.

The sort rules:
1. The number of path segments
2. The number of query parameters
3. The number of variable in path

It can make the elements sorted like:
```
/recipes/search?q={}
/recipes/popular
/recipes/{id}
/{a}/{b}
```