### PR TITLE
Validate the deep link method return type

### DIFF
--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorTest.java
@@ -225,7 +225,7 @@ public class DeepLinkProcessorTest {
             + "import com.airbnb.deeplinkdispatch.DeepLink; "
             + "public class SampleActivity {"
             + "  @DeepLink(\"airbnb://host/{arbitraryNumber}\")"
-            + "  public Intent intentFromNoStatic(Context context){"
+            + "  public Intent intentFromNoStatic(Context context) {"
             + "    return new Intent();"
             + "  }"
             + "}"
@@ -359,5 +359,29 @@ public class DeepLinkProcessorTest {
                     + "    return null;\n"
                     + "  }"
                     + "}"));
+  }
+
+  @Test public void testNonAppCompatTaskStackBuilderClassErrorMessage() {
+    JavaFileObject sampleActivity = JavaFileObjects
+        .forSourceString("SampleActivity", "package com.example;"
+            + "import com.airbnb.deeplinkdispatch.DeepLink; "
+            + "import android.content.Context;\n"
+            + "import android.app.TaskStackBuilder;\n"
+            + "import android.content.Intent;\n"
+            + "public class SampleActivity {"
+            + "  @DeepLink(\"airbnb://host/{arbitraryNumber}\")"
+            + "  public static TaskStackBuilder intentFromNoStatic(Context context) {"
+            + "    return TaskStackBuilder.create(context);"
+            + "  }"
+            + "}"
+        );
+
+    assertAbout(javaSource())
+        .that(sampleActivity)
+        .processedWith(new DeepLinkProcessor())
+        .failsToCompile()
+        .withErrorContaining(
+            "Only `Intent` or `android.support.v4.app.TaskStackBuilder` are supported."
+                + " Please double check your imports and try again.");
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-PROJECT_VERSION=4.0.0-SNAPSHOT
+PROJECT_VERSION=3.1.0-SNAPSHOT
 PROJECT_GROUP_ID=com.airbnb
 PROJECT_URL=https://github.com/airbnb/deeplinkdispatch
 PROJECT_DESCRIPTION=Library designed to handle deep linking in an Android application.


### PR DESCRIPTION
This is now performed during compilation, so if people use the wrong
return type for deep link annotated methods, compilation is gonna fail
instead of blowing up at runtime.

Fixes #163 