### PR TITLE
Fix "options were not recognized by any processor" warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.2
-    - android-25
+    - build-tools-26.0.2
+    - android-26
     - extra-google-google_play_services
     - extra-android-m2repository
     - extra-android-support

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
   repositories {
     jcenter()
+    google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.1'
+    classpath 'com.android.tools.build:gradle:2.3.3'
     classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   }
 }
@@ -13,6 +14,7 @@ buildscript {
 allprojects {
   repositories {
     jcenter()
+    google()
   }
 }
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -106,7 +106,6 @@
         <!--module name="InnerAssignment"/-->
         <!--module name="MagicNumber"/-->
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -55,6 +55,7 @@ import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -73,6 +74,7 @@ import static com.airbnb.deeplinkdispatch.Utils.decapitalize;
 import static com.google.auto.common.MoreElements.getAnnotationMirror;
 
 @AutoService(Processor.class)
+@SupportedOptions(Documentor.DOC_OUTPUT_PROPERTY_NAME)
 public class DeepLinkProcessor extends AbstractProcessor {
   private static final ClassName ANDROID_BUNDLE = ClassName.get("android.os", "Bundle");
   private static final String DLD_PACKAGE_NAME = "com.airbnb.deeplinkdispatch";
@@ -106,6 +108,10 @@ public class DeepLinkProcessor extends AbstractProcessor {
 
   @Override public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latestSupported();
+  }
+
+  @Override public Set<String> getSupportedOptions() {
+    return Collections.singleton(Documentor.DOC_OUTPUT_PROPERTY_NAME);
   }
 
   @Override

--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -6,8 +6,8 @@ apply plugin: 'com.bmuschko.nexus'
 apply plugin: 'checkstyle'
 
 dependencies {
-  compile 'com.squareup.okio:okio:1.11.0'
-  compile 'com.google.code.findbugs:jsr305:3.0.1'
+  compile 'com.squareup.okio:okio:1.13.0'
+  compile 'com.google.code.findbugs:jsr305:3.0.2'
   testCompile 'junit:junit:4.12'
   testCompile 'org.assertj:assertj-core:1.7.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,13 +8,13 @@ checkstyle {
 }
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.2"
+  compileSdkVersion 26
+  buildToolsVersion "26.0.2"
 
   defaultConfig {
     applicationId "com.airbnb.deeplinkdispatch.sample"
     minSdkVersion 16
-    targetSdkVersion 25
+    targetSdkVersion 26
     versionCode 1
     versionName "1.0"
   }
@@ -31,9 +31,10 @@ dependencies {
   annotationProcessor project(':deeplinkdispatch-processor')
 
   compile project(':sample-library')
-  compile 'com.android.support:appcompat-v7:25.1.0'
+  compile 'com.android.support:appcompat-v7:26.1.0'
 
-  testCompile 'org.robolectric:robolectric:3.2'
+  testCompile 'org.robolectric:robolectric:3.5'
+  testCompile 'org.robolectric:shadows-supportv4:3.5'
   testCompile 'junit:junit:4.12'
 }
 

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivityTest.java
@@ -1,12 +1,11 @@
 package com.airbnb.deeplinkdispatch.sample;
 
-import com.google.common.collect.ImmutableList;
-
 import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 
 import com.airbnb.deeplinkdispatch.DeepLink;
+import com.google.common.collect.ImmutableList;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,8 +84,8 @@ public class CustomPrefixesActivityTest {
 
   private Intent getLaunchedIntent(String uri) {
     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
-    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
-        .withIntent(intent).create().get();
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+        .create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 
     return shadowActivity.peekNextStartedActivityForResult().intent;

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
@@ -28,8 +28,8 @@ public class MainActivityTest {
   @Test public void testIntent() {
     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://host/somePath/1234321"))
         .putExtra("TEST_EXTRA", "FOO");
-    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
-        .withIntent(intent).create().get();
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+        .create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
     Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
     assertThat(launchedIntent.getComponent(),
@@ -48,8 +48,8 @@ public class MainActivityTest {
 
   @Test public void testQueryParams() {
     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://classDeepLink?foo=bar"));
-    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
-        .withIntent(intent).create().get();
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+        .create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 
     Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
@@ -66,8 +66,8 @@ public class MainActivityTest {
   @Test public void testQueryParamsWithBracket() {
     Intent intent =
         new Intent(Intent.ACTION_VIEW, Uri.parse("dld://classDeepLink?foo[max]=123"));
-    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
-        .withIntent(intent).create().get();
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+        .create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 
     Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
@@ -83,8 +83,8 @@ public class MainActivityTest {
   @Test public void testHttpScheme() {
     Intent intent = new Intent(Intent.ACTION_VIEW,
         Uri.parse("http://example.com/fooball?baz=something"));
-    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
-        .withIntent(intent).create().get();
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+        .create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 
     Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
@@ -102,8 +102,8 @@ public class MainActivityTest {
   @Test public void testTaskStackBuilderIntents() {
     Intent intent = new Intent(Intent.ACTION_VIEW,
         Uri.parse("http://example.com/deepLink/testid/testname/testplace"));
-    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
-        .withIntent(intent).create().get();
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+        .create().get();
     ShadowApplication shadowApplication = shadowOf(RuntimeEnvironment.application);
     Intent launchedIntent = shadowApplication.getNextStartedActivity();
     assertNotNull(launchedIntent);

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/SecondActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/SecondActivityTest.java
@@ -23,8 +23,8 @@ public class SecondActivityTest {
   @Test public void testIntent() {
     Intent intent = new Intent(Intent.ACTION_VIEW,
         Uri.parse("http://example.com/deepLink/123/myname"));
-    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class)
-        .withIntent(intent).create().get();
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+        .create().get();
     ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
 
     Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/ShadowTaskStackBuilder.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/ShadowTaskStackBuilder.java
@@ -9,7 +9,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
-import org.robolectric.internal.Shadow;
+import org.robolectric.shadow.api.Shadow;
 
 import java.util.ArrayList;
 


### PR DESCRIPTION
Even though the deep link doc was being correctly generated, the processor would still raise a warning about the `deepLinkDoc.output` option not being recognized, since it was not declared.
By overriding`getSupportedOptions` and annotating the processor with `@SupportedOptions` that warning goes away.
Also bumps versions for Robolectric, Gradle plugin, Okio, etc.
Fixes #203 