### PR TITLE
Make sure DeepLinkDispatch can work with Proguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ annotation. A popular use case for this is with web versus app deep links:
 ```java
 // Prefix all app deep link URIs with "app://airbnb"
 @DeepLinkSpec(prefix = { "app://airbnb" })
+@Retention(RetentionPolicy.CLASS)
 public @interface AppDeepLink {
   String[] value();
 }
@@ -173,6 +174,7 @@ public @interface AppDeepLink {
 ```java
 // Prefix all web deep links with "http://airbnb.com" and "https://airbnb.com"
 @DeepLinkSpec(prefix = { "http://airbnb.com", "https://airbnb.com" })
+@Retention(RetentionPolicy.CLASS)
 public @interface WebDeepLink {
   String[] value();
 }
@@ -285,17 +287,17 @@ The documentation will be generated in the following format:
 ## Proguard Rules
 
 ```
--keep class com.airbnb.deeplinkdispatch.** { *; }
+-keep @interface com.airbnb.deeplinkdispatch.DeepLink
 -keepclasseswithmembers class * {
-     @com.airbnb.deeplinkdispatch.DeepLink <methods>;
+    @com.airbnb.deeplinkdispatch.DeepLink <methods>;
 }
 ```
 **Note:** remember to include Proguard rules to keep Custom annotations you have used, for example by package:
 
 ```
--keep @interface your.package.path.deeplink.** { *; }
+-keep @interface your.package.path.deeplink.<annotation class name>
 -keepclasseswithmembers class * {
-    @your.package.path.deeplink.* <methods>;
+    @your.package.path.deeplink.<annotation class name> <methods>;
 }
 ```
 

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLink.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLink.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * </code></pre>
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface DeepLink {
   String IS_DEEP_LINK = "is_deep_link_flag";
   String URI = "deep_link_uri";

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
Need to keep annotation itself for class level as only that way we can
define a Proguard rule that keeps the name of the methods with that
annotation.

Update README.md with new proguard rules that work.

Need to keep the annotation itself because as it is never read in code
it would be removed by proguard in the shrinking step (which is before
obfuscation) then during obfuscation it would not be there anymore to
work as the anchor point to keep the names.

Update gradle to latest.