### PR TITLE
Change deeplinkdispatch-base artifact name

### DIFF
--- a/deeplinkdispatch-base/build.gradle
+++ b/deeplinkdispatch-base/build.gradle
@@ -29,7 +29,7 @@ modifyPom {
     inceptionYear '2015'
     version PROJECT_VERSION
     groupId PROJECT_GROUP_ID
-    artifactId 'deeplinkdispatchbase'
+    artifactId 'deeplinkdispatch-base'
 
     scm {
       url PROJECT_URL


### PR DESCRIPTION
In https://github.com/airbnb/DeepLinkDispatch/pull/221 I renamed the project to deeplinkdispatch-base, but forgot to rename the artifact.