### PR TITLE
Add Uri template to deeplink broadcast

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -34,15 +34,18 @@ public final class DeepLinkEntry {
   private final String method;
   private final Set<String> parameters;
   private final Pattern regex;
+  private final String uriTemplate;
 
   public enum Type {
     CLASS,
     METHOD
   }
 
-  public DeepLinkEntry(String uri, Type type, Class<?> activityClass, String method) {
-    DeepLinkUri parsedUri = DeepLinkUri.parse(uri);
+  public DeepLinkEntry(String uriTemplate, Type type, Class<?> activityClass, String method) {
+    DeepLinkUri parsedUri = DeepLinkUri.parse(uriTemplate);
     String schemeHostAndPath = schemeHostAndPath(parsedUri);
+
+    this.uriTemplate = uriTemplate;
     this.type = type;
     this.activityClass = activityClass;
     this.method = method;
@@ -97,6 +100,10 @@ public final class DeepLinkEntry {
       }
     }
     return paramsMap;
+  }
+
+  public String getUriTemplate(){
+    return this.uriTemplate;
   }
 
   private static String parsePath(DeepLinkUri parsedUri) {

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.java
@@ -102,7 +102,7 @@ public final class DeepLinkEntry {
     return paramsMap;
   }
 
-  public String getUriTemplate(){
+  public String getUriTemplate() {
     return this.uriTemplate;
   }
 

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkHandler.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkHandler.java
@@ -38,5 +38,6 @@ public @interface DeepLinkHandler {
   String ACTION = "com.airbnb.deeplinkdispatch.DEEPLINK_ACTION";
   String EXTRA_SUCCESSFUL = "com.airbnb.deeplinkdispatch.EXTRA_SUCCESSFUL";
   String EXTRA_URI = "com.airbnb.deeplinkdispatch.EXTRA_URI";
+  String EXTRA_URI_TEMPLATE = "com.airbnb.deeplinkdispatch.EXTRA_URI_TEMPLATE";
   String EXTRA_ERROR_MESSAGE = "com.airbnb.deeplinkdispatch.EXTRA_ERROR_MESSAGE";
 }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -51,7 +51,8 @@ public class BaseDeepLinkDelegate {
     }
     Uri uri = sourceIntent.getData();
     if (uri == null) {
-      return createResultAndNotify(activity, false, null, null, "No Uri in given activity's intent.");
+      return createResultAndNotify(activity, false, null,
+              null, "No Uri in given activity's intent.");
     }
     String uriString = uri.toString();
     DeepLinkEntry entry = findEntry(uriString);
@@ -89,8 +90,9 @@ public class BaseDeepLinkDelegate {
             if (method.getReturnType().equals(TaskStackBuilder.class)) {
               taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity);
               if (taskStackBuilder.getIntentCount() == 0) {
-                return createResultAndNotify(activity, false, uri,
-                        entry.getUriTemplate(), "Could not deep link to method: " + entry.getMethod() + " intents length == 0");
+                return createResultAndNotify(activity, false, uri, entry.getUriTemplate(),
+                        "Could not deep link to method: "
+                                + entry.getMethod() + " intents length == 0");
               }
               newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
             } else {
@@ -101,8 +103,9 @@ public class BaseDeepLinkDelegate {
             if (method.getReturnType().equals(TaskStackBuilder.class)) {
               taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity, parameters);
               if (taskStackBuilder.getIntentCount() == 0) {
-                return createResultAndNotify(activity, false, uri,
-                        entry.getUriTemplate(), "Could not deep link to method: " + entry.getMethod() + " intents length == 0");
+                return createResultAndNotify(activity, false, uri, entry.getUriTemplate(),
+                        "Could not deep link to method: "
+                                + entry.getMethod() + " intents length == 0");
               }
               newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
             } else {
@@ -139,13 +142,14 @@ public class BaseDeepLinkDelegate {
                 entry.getUriTemplate(), "Could not deep link to method: " + entry.getMethod());
       }
     } else {
-      return createResultAndNotify(activity, false, uri,
-              entry.getUriTemplate(), "No registered entity to handle deep link: " + uri.toString());
+      return createResultAndNotify(activity, false, uri, entry.getUriTemplate(),
+              "No registered entity to handle deep link: " + uri.toString());
     }
   }
 
-  private static DeepLinkResult createResultAndNotify(Context context, final boolean successful,
-                                                      final Uri uri, String uriTemplate, final String error) {
+  private static DeepLinkResult createResultAndNotify(Context context,
+                                                      final boolean successful, final Uri uri,
+                                                      String uriTemplate, final String error) {
     notifyListener(context, !successful, uri, uriTemplate, error);
     return new DeepLinkResult(successful, uri != null ? uri.toString() : null, error);
   }

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -145,6 +145,16 @@ public class DeepLinkEntryTest {
       .contains(entry("foo", "baz"), entry("bar", "qux"));
   }
 
+  @Test public void templateWithoutParameters() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://something");
+    assertThat("airbnb://something".equals(entry.getUriTemplate())).isTrue();
+  }
+
+  @Test public void templatewithParameters() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}/{param2}");
+    assertThat("airbnb://test/{param1}/{param2}".equals(entry.getUriTemplate())).isTrue();
+  }
+
   private static DeepLinkEntry deepLinkEntry(String uri) {
     return new DeepLinkEntry(uri, DeepLinkEntry.Type.CLASS, String.class, null);
   }

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -150,7 +150,7 @@ public class DeepLinkEntryTest {
     assertThat("airbnb://something".equals(entry.getUriTemplate())).isTrue();
   }
 
-  @Test public void templatewithParameters() {
+  @Test public void templateWithParameters() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}/{param2}");
     assertThat("airbnb://test/{param1}/{param2}".equals(entry.getUriTemplate())).isTrue();
   }


### PR DESCRIPTION
- Add Uri template (the one that is given in the annotation) as `EXTRA_URI_TEMPLATE` in `DEEPLINK_ACTION` broadcast.
- Updated tests to also contain new `getUriTemplate()` method

This fixes https://github.com/airbnb/DeepLinkDispatch/issues/187