### PR TITLE
Add android-maven plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,14 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-28.0.1
     - android-28
-    - extra-google-google_play_services
-    - extra-android-m2repository
-    - extra-android-support
-    - extra-google-m2repository
-  licenses:
-    - 'android-sdk-preview-license-.+'
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
 
 after_success:
   - .buildscript/deploy_snapshot.sh
+
+before_install:
+    - mkdir "$ANDROID_HOME/licenses" || true
+    - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
 
 jdk:
   - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
   dependencies {
     classpath deps.androidPlugin
     classpath deps.nexusPlugin
+    classpath deps.androidMavenPlugin
   }
 }
 

--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -4,6 +4,7 @@ sourceCompatibility = 1.7
 
 apply plugin: 'com.bmuschko.nexus'
 apply plugin: 'checkstyle'
+apply plugin: 'com.github.dcendents.android-maven' 
 
 dependencies {
   api project(':deeplinkdispatch-base')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [
 
 ext.versions = versions
 ext.androidConfig = [
-    agpVersion       : '3.2.0-beta04',
+    agpVersion       : '3.2.0',
     compileSdkVersion: 28,
     buildToolsVersion: '28.0.1',
     minSdkVersion    : 16,
@@ -19,6 +19,7 @@ ext.deps = [
     appCompat                : "androidx.appcompat:appcompat:$versions.androixVersion",
     localBroadcastManager    : "androidx.localbroadcastmanager:localbroadcastmanager:$versions.androixVersion",
     nexusPlugin              : 'com.bmuschko:gradle-nexus-plugin:2.3.1',
+    androidMavenPlugin       : 'com.github.dcendents:android-maven-gradle-plugin:2.1',
     kotlinStdLib             : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlinVersion",
     kotlinGradlePlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinVersion",
     javaPoet                 : 'com.squareup:javapoet:1.9.0',


### PR DESCRIPTION
See: https://github.com/jitpack/jitpack.io/blob/master/ANDROID.md

From what I can tell this allows JetPack.io to find the repo:

https://jitpack.io/com/github/rogerhu/DeepLinkDispatch/maven-v3.1.1-g34b4e9c-11/build.log

```
Build artifacts:
com.github.rogerhu.DeepLinkDispatch:deeplinkdispatch:maven-v3.1.1-g34b4e9c-11
com.github.rogerhu.DeepLinkDispatch:deeplinkdispatch-processor:maven-v3.1.1-g34b4e9c-11
com.github.rogerhu.DeepLinkDispatch:deeplinkdispatch-base:maven-v3.1.1-g34b4e9c-11
```

Interestingly the maven-v3.1.1 seems to be the last tagged release, the g34b4e9c is the commit hash, and 11 marks the # of commits since the tag.
