### PR TITLE
Fix nullpointer when there is no match

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -142,7 +142,7 @@ public class BaseDeepLinkDelegate {
                 entry.getUriTemplate(), "Could not deep link to method: " + entry.getMethod());
       }
     } else {
-      return createResultAndNotify(activity, false, uri, entry.getUriTemplate(),
+      return createResultAndNotify(activity, false, uri, null,
               "No registered entity to handle deep link: " + uri.toString());
     }
   }


### PR DESCRIPTION
Entry is null in this case and we cannot access it. (There is no match)