### PR TITLE
Add Simple Markdown Support via Documentor Hijack

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,23 @@ tasks.withType(JavaCompile) {
   options.compilerArgs << "-AdeepLinkDoc.output=${buildDir}/doc/deeplinks.txt"
 }
 ```
+
+If you are using Kotlin this is how you can enable it for kapt
+```groovy
+kapt {
+  arguments {
+    arg("deepLinkDoc.output", "${buildDir}/doc/deeplinks.txt")
+  }
+}
+```
+
 The documentation will be generated in the following format:
 ```
 * {DeepLink1}\n|#|\n[Description part of javadoc]\n|#|\n{ClassName}#[MethodName]\n|##|\n
 * {DeepLink2}\n|#|\n[Description part of javadoc]\n|#|\n{ClassName}#[MethodName]\n|##|\n
 ```
+
+You can also generate the output in a much more readable Markdown format by naming the output file `*.md` (e.g. `deeplinks.md`). Make sure that your Markdown viewer understands tables.
 
 ## Proguard Rules
 

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/Documentor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/Documentor.java
@@ -25,25 +25,26 @@ import javax.tools.Diagnostic;
  * {@link ProcessingEnvironment}'s compiler argument options by deepLinkDoc.output.
  */
 final class Documentor {
-  private static final String PROPERTY_DELIMITER = "\\n|#|\\n";
-  private static final String ELEMENT_DELIMITER = "\\n|##|\\n";
-  private static final String CLASS_METHOD_NAME_DELIMITER = "#";
-  private static final String PARAM = "@param";
-  private static final String RETURN = "@return";
-  @VisibleForTesting static final String DOC_OUTPUT_PROPERTY_NAME = "deepLinkDoc.output";
+  protected static final String PROPERTY_DELIMITER = "\\n|#|\\n";
+  protected static final String ELEMENT_DELIMITER = "\\n|##|\\n";
+  protected static final String CLASS_METHOD_NAME_DELIMITER = "#";
+  protected static final String PARAM = "@param";
+  protected static final String RETURN = "@return";
+  @VisibleForTesting
+  static final String DOC_OUTPUT_PROPERTY_NAME = "deepLinkDoc.output";
 
   private final ProcessingEnvironment processingEnv;
   private final Messager messager;
 
   @Nullable private File file;
 
-  Documentor(ProcessingEnvironment processingEnv) {
+  Documentor(final ProcessingEnvironment processingEnv) {
     this.processingEnv = processingEnv;
     messager = processingEnv.getMessager();
     initFile();
   }
 
-  void write(List<DeepLinkAnnotatedElement> elements) {
+  void write(final List<DeepLinkAnnotatedElement> elements) {
     if (file == null) {
       messager.printMessage(Diagnostic.Kind.NOTE,
           "Output file is null, DeepLink doc not generated.");
@@ -55,22 +56,23 @@ final class Documentor {
       return;
     }
     try (PrintWriter writer = new PrintWriter(new FileWriter(file), true)) {
-      for (DeepLinkAnnotatedElement element : elements) {
-        writer.print(element.getUri() + PROPERTY_DELIMITER);
-        String doc = formatJavaDoc(
-            processingEnv.getElementUtils().getDocComment(element.getElement()));
-        if (doc != null) {
-          writer.print(doc);
-        }
-        writer.print(PROPERTY_DELIMITER);
-        writer.print(element.getAnnotatedElement().getSimpleName());
-        if (element.getAnnotationType().equals(DeepLinkEntry.Type.METHOD)) {
-          writer.print(CLASS_METHOD_NAME_DELIMITER);
-          writer.print(element.getMethod());
-        }
-        writer.print(ELEMENT_DELIMITER);
+
+      final String fileName = file.getName();
+      final int extIndex = fileName.lastIndexOf(".");
+
+      DocumetationWriter docWriter;
+
+      // markdown writer if .md file extension is used
+      if (extIndex >= 0 && extIndex < fileName.length()
+              && fileName.substring(extIndex + 1).equalsIgnoreCase("md")) {
+        docWriter = new MarkdownWriter();
+      } else {
+          // else default writer
+        docWriter = new GenericWriter();
       }
-      writer.flush();
+
+      docWriter.write(processingEnv, writer, elements);
+
     } catch (IOException e) {
       messager.printMessage(Diagnostic.Kind.ERROR,
           "DeepLink doc not generated: " + e.getMessage());
@@ -102,7 +104,7 @@ final class Documentor {
   }
 
   /* Strips off {@link #PARAM} and {@link #RETURN}. */
-  private static String formatJavaDoc(String str) {
+  protected static String formatJavaDoc(String str) {
     if (str != null) {
       int paramPos = str.indexOf(PARAM);
       if (paramPos != -1) {
@@ -122,4 +124,18 @@ final class Documentor {
   File getFile() {
     return file;
   }
+
+  /**
+   * Implement this interface if you want to provide own documentation writer.
+   */
+  interface DocumetationWriter {
+    /**
+     * Compose documentation with help of provided environment, writer and collection of
+     * found deeplink elements.
+     */
+    void write(final ProcessingEnvironment env,
+               final PrintWriter writer,
+               final List<DeepLinkAnnotatedElement> elements);
+  }
+
 }

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/Documentor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/Documentor.java
@@ -133,9 +133,9 @@ final class Documentor {
      * Compose documentation with help of provided environment, writer and collection of
      * found deeplink elements.
      */
-    void write(final ProcessingEnvironment env,
-               final PrintWriter writer,
-               final List<DeepLinkAnnotatedElement> elements);
+    void write(ProcessingEnvironment env,
+               PrintWriter writer,
+               List<DeepLinkAnnotatedElement> elements);
   }
 
 }

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/GenericWriter.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/GenericWriter.java
@@ -1,0 +1,40 @@
+package com.airbnb.deeplinkdispatch;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.util.Elements;
+
+/**
+ * Old documentation format.
+ */
+final class GenericWriter implements Documentor.DocumetationWriter {
+    @Override
+    public void write(final ProcessingEnvironment env,
+                      final PrintWriter writer,
+                      final List<DeepLinkAnnotatedElement> elements) {
+        final Elements utils = env.getElementUtils();
+
+        for (DeepLinkAnnotatedElement element : elements) {
+            writer.print(element.getUri() + Documentor.PROPERTY_DELIMITER);
+
+            String doc = Documentor.formatJavaDoc(utils.getDocComment(element.getElement()));
+            if (doc != null) {
+                writer.print(doc);
+            }
+
+            writer.print(Documentor.PROPERTY_DELIMITER);
+            writer.print(element.getAnnotatedElement().getSimpleName());
+
+            if (element.getAnnotationType().equals(DeepLinkEntry.Type.METHOD)) {
+                writer.print(Documentor.CLASS_METHOD_NAME_DELIMITER);
+                writer.print(element.getMethod());
+            }
+
+            writer.print(Documentor.ELEMENT_DELIMITER);
+        }
+
+        writer.flush();
+    }
+}

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/MarkdownWriter.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/MarkdownWriter.java
@@ -1,0 +1,51 @@
+package com.airbnb.deeplinkdispatch;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Locale;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Name;
+import javax.lang.model.util.Elements;
+
+/**
+ * GitHub markdown format.
+ *
+ * @see <a href="https://guides.github.com/features/mastering-markdown/">Mastering Markdown</a>
+ * @see <a href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet">Markdown
+ * Cheatsheet</a>
+ * @see <a href="https://github.com/JFormDesigner/markdown-writer-fx">Markdown Writer FX</a>
+ * @see <a href="https://stackedit.io/">Stack Edit</a>
+ */
+final class MarkdownWriter implements Documentor.DocumetationWriter {
+
+    @Override
+    public void write(final ProcessingEnvironment env,
+                      final PrintWriter writer,
+                      final List<DeepLinkAnnotatedElement> elements) {
+
+        final Elements utils = env.getElementUtils();
+
+        // header
+        writer.println("| URI | JavaDoc | Simple Name | Method |");
+        writer.println("| --- | ------- | ----------- | ------ |");
+        final String format = "| %1$s | %2$s | %3$s | %4$s |";
+
+        // publish lines
+        for (DeepLinkAnnotatedElement element : elements) {
+            String uri = element.getUri();
+            String doc = Documentor.formatJavaDoc(utils.getDocComment(element.getElement()));
+            String embeddedComments = null == doc ? "" : doc;
+            boolean isMethod = element.getAnnotationType().equals(DeepLinkEntry.Type.METHOD);
+            String methodName = isMethod ? element.getMethod() : "";
+            Name simpleName = element.getAnnotatedElement().getSimpleName();
+
+            String line = String.format(Locale.US, format,
+                    uri, embeddedComments, simpleName, methodName);
+
+            writer.println(line);
+        }
+
+        writer.flush();
+    }
+}


### PR DESCRIPTION
Attempt 3 to get this in. The first two authors seemed to have abandoned their PRs: #119 and #213 

This PR takes that work, addresses the comments in #119 and the CI errors in #213 to hopefully create a building acceptable PR to get markdown support in the library.

Also helps address Issue #236.

Recommend closing the previous two PRs.