### PR TITLE
Restored old null behavior

### DIFF
--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   implementation deps.jsr305
   implementation deps.localBroadcastManager
   implementation deps.appCompat
+  testImplementation deps.mockito
   testImplementation deps.junit
   testImplementation deps.assertJ
 }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -221,18 +221,18 @@ public class BaseDeepLinkDelegate {
     return null;
   }
 
-  private void validateInput(Activity activity, Intent sourceIntent){
+  private void validateInput(Activity activity, Intent sourceIntent) {
     validateInput(activity);
     validateInput(sourceIntent);
   }
 
-  private void validateInput(Activity activity){
+  private void validateInput(Activity activity) {
     if (activity == null) {
       throw new NullPointerException("activity == null");
     }
   }
 
-  private void validateInput(Intent sourceIntent){
+  private void validateInput(Intent sourceIntent) {
     if (sourceIntent == null) {
       throw new NullPointerException("sourceIntent == null");
     }

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.java
@@ -1,0 +1,178 @@
+package com.airbnb.deeplinkdispatch;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BaseDeepLinkDelegateTest {
+
+  @Test
+  public void testDispatchNullActivity() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
+    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    String message = null;
+    try {
+      testDelegate.dispatchFrom(null);
+    } catch (NullPointerException e) {
+      message = e.getMessage();
+    }
+
+    assertThat(message).isEqualTo("activity == null");
+  }
+
+  @Test
+  public void testDispatchNullActivityNullIntent() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
+    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    String message = null;
+    try {
+      testDelegate.dispatchFrom(null, null);
+    } catch (NullPointerException e) {
+      message = e.getMessage();
+    }
+
+    assertThat(message).isEqualTo("activity == null");
+  }
+
+  @Test
+  public void testDispatchNullIntent() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
+    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+
+    Activity activity = mock(Activity.class);
+    when(activity.getIntent())
+      .thenReturn(null);
+
+    String message = null;
+    try {
+      testDelegate.dispatchFrom(activity);
+    } catch (NullPointerException e) {
+      message = e.getMessage();
+    }
+
+    assertThat(message).isEqualTo("sourceIntent == null");
+  }
+
+  @Test
+  public void testDispatchNonNullActivityNullIntent() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
+    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+
+    Activity activity = mock(Activity.class);
+    when(activity.getIntent())
+      .thenReturn(null);
+
+    String message = null;
+    try {
+      testDelegate.dispatchFrom(activity, null);
+    } catch (NullPointerException e) {
+      message = e.getMessage();
+    }
+
+    assertThat(message).isEqualTo("sourceIntent == null");
+  }
+
+  @Test
+  public void testCreateResultAllNull() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
+    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+
+    String message = null;
+    try {
+      testDelegate.createResult(null, null, null);
+    } catch (NullPointerException e) {
+      message = e.getMessage();
+    }
+
+    assertThat(message).isEqualTo("activity == null");
+  }
+
+  @Test
+  public void testCreateResultNullIntent() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
+    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+
+    Activity activity = mock(Activity.class);
+    when(activity.getIntent())
+      .thenReturn(null);
+
+    String message = null;
+    try {
+      testDelegate.createResult(activity, null, null);
+    } catch (NullPointerException e) {
+      message = e.getMessage();
+    }
+
+    assertThat(message).isEqualTo("sourceIntent == null");
+  }
+
+  @Test
+  public void testCreateResultAllNullData() {
+    DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
+    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+
+    Intent intent = mock(Intent.class);
+    when(intent.getData())
+      .thenReturn(null);
+    Activity activity = mock(Activity.class);
+    when(activity.getIntent())
+      .thenReturn(intent);
+
+    DeepLinkResult result = testDelegate.createResult(activity, intent, null);
+
+    assertThat(result).isEqualTo(new DeepLinkResult(
+      false, null, "No Uri in given activity's intent.", null, null, null));
+  }
+
+  private static DeepLinkEntry deepLinkEntry(String uri) {
+    return new DeepLinkEntry(uri, DeepLinkEntry.Type.CLASS, String.class, null);
+  }
+
+  /**
+   * Helper method to get a class extending {@link BaseRegistry} acting as the delegate
+   * for the
+   *
+   * @param deepLinkEntries
+   * @return
+   */
+  private static TestDeepLinkRegistry getTestRegistry(List<DeepLinkEntry> deepLinkEntries) {
+    return new TestDeepLinkRegistry(deepLinkEntries);
+  }
+
+  private static class TestDeepLinkRegistry extends BaseRegistry {
+    public TestDeepLinkRegistry(List<DeepLinkEntry> registry) {
+      super(registry, getSearchIndex(registry), new HashSet<String>());
+    }
+
+    @NotNull
+    private static byte[] getSearchIndex(List<DeepLinkEntry> registry) {
+      Root trieRoot = new Root();
+      for (int i = 0; i < registry.size(); i++) {
+        trieRoot.addToTrie(i, DeepLinkUri.parse(registry.get(i).getUriTemplate()), registry.get(i).getActivityClass().toString(), registry.get(i).getMethod());
+      }
+      return trieRoot.toUByteArray();
+    }
+  }
+
+  private static TestDeepLinkDelegate getTestDelegate(List<DeepLinkEntry> entries) {
+    return new TestDeepLinkDelegate(Arrays.asList(getTestRegistry(entries)));
+  }
+
+  private static class TestDeepLinkDelegate extends BaseDeepLinkDelegate {
+
+    public TestDeepLinkDelegate(List<? extends BaseRegistry> registries) {
+      super(registries);
+    }
+  }
+
+}

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -14,14 +14,14 @@ import static org.assertj.core.api.Assertions.entry;
 public class DeepLinkEntryTest {
   @Test public void testSingleParam() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://foo/myData"));
     assertThat(match.getParameters(DeepLinkUri.parse("airbnb://foo/myData")).get("bar")).isEqualTo("myData");
   }
 
   @Test public void testTwoParams() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}/{param2}");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://test/12345/alice"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://test/12345/alice"));
@@ -31,7 +31,7 @@ public class DeepLinkEntryTest {
 
   @Test public void testParamWithSpecialCharacters() throws Exception {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://foo/hyphens-and_underscores123"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://foo/hyphens-and_underscores123"));
@@ -40,7 +40,7 @@ public class DeepLinkEntryTest {
 
   @Test public void testParamWithTildeAndDollarSign() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://test/tilde~dollar$ign"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://test/tilde~dollar$ign"));
@@ -49,7 +49,7 @@ public class DeepLinkEntryTest {
 
   @Test public void testParamWithDotAndComma() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://test/N1.55,22.11"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://test/N1.55,22.11"));
@@ -58,7 +58,7 @@ public class DeepLinkEntryTest {
 
   @Test public void testParamForAtSign() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://test/somename@gmail.com"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://test/somename@gmail.com"));
@@ -67,7 +67,7 @@ public class DeepLinkEntryTest {
 
   @Test public void testParamForColon() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://test/a1:b2:c3"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://test/a1:b2:c3"));
@@ -76,7 +76,7 @@ public class DeepLinkEntryTest {
 
   @Test public void testParamWithSlash() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://test/{param1}/foo");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://test/123/foo"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://test/123/foo"));
@@ -85,7 +85,7 @@ public class DeepLinkEntryTest {
 
   @Test public void testNoMatchesFound() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     assertThat(testRegistry.idxMatch(DeepLinkUri.parse("airbnb://test.com"))).isNull();
     assertThat(entry.getParameters(DeepLinkUri.parse("airbnb://test.com")).isEmpty()).isTrue();
   }
@@ -94,7 +94,7 @@ public class DeepLinkEntryTest {
   public void testEmptyParametersDontMatch() throws Exception {
     DeepLinkEntry entry = deepLinkEntry("dld://foo/{id}/bar");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("dld://foo//bar"));
 
     assertThat(match).isNull();
@@ -104,7 +104,7 @@ public class DeepLinkEntryTest {
   public void testEmptyParametersNameDontMatch() throws Exception {
     DeepLinkEntry entry = deepLinkEntry("dld://foo/{}/bar");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("dld://foo/bla/bar"));
 
     assertThat(match).isNull();
@@ -115,10 +115,10 @@ public class DeepLinkEntryTest {
     DeepLinkEntry entry = deepLinkEntry("dld://foo/{id}");
     DeepLinkEntry entryNoParam = deepLinkEntry("dld://foo");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("dld://foo"));
 
-    TestDeepLinkRegistry testRegistryNoParam = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entryNoParam}));
+    TestDeepLinkRegistry testRegistryNoParam = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entryNoParam}));
     DeepLinkEntry matchNoParam = testRegistryNoParam.idxMatch(DeepLinkUri.parse("dld://foo"));
 
     assertThat(match).isNull();
@@ -135,7 +135,7 @@ public class DeepLinkEntryTest {
   @Test public void noMatches() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://something.com/some-path");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://something.com/something-else"));
 
     assertThat(match).isNull();
@@ -144,7 +144,7 @@ public class DeepLinkEntryTest {
   @Test public void pathParamAndQueryString() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://foo/baz?kit=kat"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://foo/baz?kit=kat"));
@@ -154,7 +154,7 @@ public class DeepLinkEntryTest {
   @Test public void urlWithSpaces() {
     DeepLinkEntry entry = deepLinkEntry("http://example.com/{query}");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("http://example.com/search%20paris"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("http://example.com/search%20paris"));
@@ -164,7 +164,7 @@ public class DeepLinkEntryTest {
   @Test public void noMatchesDifferentScheme() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://something");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("http://something"));
 
     assertThat(match).isNull();
@@ -173,7 +173,7 @@ public class DeepLinkEntryTest {
   @Test public void testNoMatchForPartialOfRealMatch() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://host/something/something");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://host/something"));
 
     assertThat(match).isNull();
@@ -182,7 +182,7 @@ public class DeepLinkEntryTest {
   @Test public void invalidUrl() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://something");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://"));
 
     assertThat(match).isNull();
@@ -191,7 +191,7 @@ public class DeepLinkEntryTest {
   @Test public void pathWithQuotes() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://s/{query}");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://s/Sant'Eufemia-a-Maiella--Italia"));
 
     assertThat(match).isEqualTo(entry);
@@ -200,7 +200,7 @@ public class DeepLinkEntryTest {
   @Test public void schemeWithNumbers() {
     DeepLinkEntry entry = deepLinkEntry("jackson5://example.com");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("jackson5://example.com"));
 
     assertThat(match).isEqualTo(entry);
@@ -209,7 +209,7 @@ public class DeepLinkEntryTest {
   @Test public void multiplePathParams() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://{foo}/{bar}");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entry}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
     DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://baz/qux"));
 
     Map<String, String> parameters = match.getParameters(DeepLinkUri.parse("airbnb://baz/qux"));
@@ -222,7 +222,7 @@ public class DeepLinkEntryTest {
     DeepLinkEntry entryMatch = deepLinkEntry("airbnb://{foo}/{bar}/match");
     DeepLinkEntry entryNoMatch = deepLinkEntry("airbnb://{hey}/{ho}/noMatch");
 
-    TestDeepLinkRegistry testRegistry = getTestDelegate(Arrays.asList(new DeepLinkEntry[] {entryNoMatch,entryMatch}));
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entryNoMatch,entryMatch}));
     DeepLinkUri matchUri = DeepLinkUri.parse("airbnb://baz/qux/match");
     DeepLinkEntry match = testRegistry.idxMatch(matchUri);
 
@@ -247,12 +247,12 @@ public class DeepLinkEntryTest {
   }
 
   /**
-   * Helper method to get a class extending {@link BaseDeepLinkDelegate} acting as the delegate
+   * Helper method to get a class extending {@link BaseRegistry} acting as the delegate
    * for the
    * @param deepLinkEntries
    * @return
    */
-  private static TestDeepLinkRegistry getTestDelegate(List<DeepLinkEntry> deepLinkEntries){
+  private static TestDeepLinkRegistry getTestRegistry(List<DeepLinkEntry> deepLinkEntries){
     return new TestDeepLinkRegistry(deepLinkEntries);
   }
 


### PR DESCRIPTION
- Restore old null behavior for activity, intent and intent data on createResult and dispatchFrom.
- Added unit tests to test that behavior.
- Cleanup.

This fixes https://github.com/airbnb/DeepLinkDispatch/issues/282