### PR TITLE
Match deterministically across registries

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
@@ -15,6 +15,8 @@
  */
 package com.airbnb.deeplinkdispatch
 
+import kotlin.math.min
+
 class DeepLinkEntry(val uriTemplate: String,
                     val type: Type,
                     /**
@@ -29,6 +31,24 @@ class DeepLinkEntry(val uriTemplate: String,
 
     private val parameterMap: MutableMap<DeepLinkUri, Map<String, String>> = mutableMapOf()
 
+    private val firstConfigurablePathSegmentIndex: Int by lazy { uriTemplate.indexOf(configurablePathSegmentPrefixChar) }
+    private val firstPlaceholderIndex: Int by lazy { uriTemplate.indexOf(componentParamPrefixChar) }
+    private val firstNonConcreteIndex: Int by lazy {
+        if (firstPlaceholderIndex == -1 && firstConfigurablePathSegmentIndex == -1) {
+            -1
+        } else {
+            if (firstConfigurablePathSegmentIndex == -1) {
+                firstPlaceholderIndex
+            } else {
+                if(firstPlaceholderIndex == -1){
+                    firstConfigurablePathSegmentIndex
+                } else {
+                    min(firstConfigurablePathSegmentIndex, firstPlaceholderIndex)
+                }
+            }
+        }
+    }
+
     /**
      * Generates a map of parameters and the values from the given deep link.
      *
@@ -36,10 +56,36 @@ class DeepLinkEntry(val uriTemplate: String,
      * @return the map of parameter values, where all values will be strings.
      */
     fun getParameters(inputUri: DeepLinkUri): Map<String, String> {
-        return parameterMap.get(inputUri) ?: emptyMap()
+        return parameterMap[inputUri] ?: emptyMap()
     }
 
     fun setParameters(deepLinkUri: DeepLinkUri, parameterMap: Map<String, String>) {
         this.parameterMap[deepLinkUri] = parameterMap
     }
+
+    override fun toString(): String {
+        return "uriTemplate: $uriTemplate type: $type activity: ${activityClass.simpleName} method: $method parameters: $parameterMap"
+    }
+
+    /**
+     * Whatever template has the first placeholder (and then configurable path segment) is the less
+     * concrete one.
+     * Because if they would have been all in the same index those elements would have been on the
+     * same level and in the same "list" of elements we compare in order.
+     * In this case the one with the more concete element would have won and the same is true here.
+     */
+    fun moreConcreteThan(compare: DeepLinkEntry): Int {
+        return when {
+            this.firstNonConcreteIndex < compare.firstNonConcreteIndex -> -1
+            this.firstNonConcreteIndex == compare.firstNonConcreteIndex -> {
+                if (this.firstNonConcreteIndex == -1 || uriTemplate[firstNonConcreteIndex] == compare.uriTemplate[firstNonConcreteIndex]) {
+                    0
+                } else if (this.uriTemplate[firstNonConcreteIndex] == configurablePathSegmentPrefixChar) {
+                    -1
+                } else 1
+            }
+            else -> 1
+        }
+    }
+
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
@@ -22,7 +22,7 @@ class DeepLinkEntry(val uriTemplate: String,
                     /**
                      * The class where the annotation corresponding to where an instance of DeepLinkEntry is declared.
                      */
-                    val activityClass: Class<*>, val method: String?) {
+                    val activityClass: Class<*>, val method: String?) : Comparable<DeepLinkEntry> {
 
     enum class Type {
         CLASS,
@@ -40,7 +40,7 @@ class DeepLinkEntry(val uriTemplate: String,
             if (firstConfigurablePathSegmentIndex == -1) {
                 firstPlaceholderIndex
             } else {
-                if(firstPlaceholderIndex == -1){
+                if (firstPlaceholderIndex == -1) {
                     firstConfigurablePathSegmentIndex
                 } else {
                     min(firstConfigurablePathSegmentIndex, firstPlaceholderIndex)
@@ -74,11 +74,11 @@ class DeepLinkEntry(val uriTemplate: String,
      * same level and in the same "list" of elements we compare in order.
      * In this case the one with the more concete element would have won and the same is true here.
      */
-    fun moreConcreteThan(compare: DeepLinkEntry): Int {
+    override fun compareTo(other: DeepLinkEntry): Int {
         return when {
-            this.firstNonConcreteIndex < compare.firstNonConcreteIndex -> -1
-            this.firstNonConcreteIndex == compare.firstNonConcreteIndex -> {
-                if (this.firstNonConcreteIndex == -1 || uriTemplate[firstNonConcreteIndex] == compare.uriTemplate[firstNonConcreteIndex]) {
+            this.firstNonConcreteIndex < other.firstNonConcreteIndex -> -1
+            this.firstNonConcreteIndex == other.firstNonConcreteIndex -> {
+                if (this.firstNonConcreteIndex == -1 || uriTemplate[firstNonConcreteIndex] == other.uriTemplate[firstNonConcreteIndex]) {
                     0
                 } else if (this.uriTemplate[firstNonConcreteIndex] == configurablePathSegmentPrefixChar) {
                     -1
@@ -87,5 +87,4 @@ class DeepLinkEntry(val uriTemplate: String,
             else -> 1
         }
     }
-
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/UrlTree.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/UrlTree.kt
@@ -148,6 +148,10 @@ fun UByteArray.writeUShortAt(startIndex: Int, value: UShort) {
 }
 
 const val configurablePathSegmentPrefix = "<"
+const val configurablePathSegmentPrefixChar = configurablePathSegmentPrefix.get(0)
 const val configurablePathSegmentSuffix = ">"
+const val configurablePathSegmentSuffixChar = configurablePathSegmentSuffix.get(0)
 const val componentParamPrefix = "{"
+const val componentParamPrefixChar = componentParamPrefix.get(0)
 const val componentParamSuffix = "}"
+const val componentParamSuffixChar = componentParamSuffix.get(0)

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -223,6 +223,9 @@ public class MatchIndex {
         replacementValue = pathSegmentEntry.getValue();
       }
     }
+    if (replacementValue == null) {
+      return null;
+    }
     if (replacementValue.length == 0) {
       return new CompareResult("", true);
     }
@@ -284,10 +287,10 @@ public class MatchIndex {
   /**
    * Get the next entries position, or -1 if there are no further entries.
    *
-   * @param elementStartPos   The start postion of the current element.
+   * @param elementStartPos   The start position of the current element.
    * @param parentBoundaryPos The parent elements boundry (i.e. the first elementStartPos that is
    *                          not part of the parent element anhymore)
-   * @return
+   * @return The next entries position, or -1 if there are no further entries.
    */
   private int getNextElementStartPosition(int elementStartPos, int parentBoundaryPos) {
     int nextElementPos = getElementBoundaryPos(elementStartPos);
@@ -303,8 +306,8 @@ public class MatchIndex {
    * The elements boundary is the first elementStartPos that is not part of the parent element
    * anymore.
    *
-   * @param elementStartPos
-   * @return
+   * @param elementStartPos The start position of the current element.
+   * @return The first elementStartPos that is not part of the parent element anymore.
    */
   private int getElementBoundaryPos(int elementStartPos) {
     return elementStartPos + HEADER_LENGTH + getValueLength(elementStartPos)
@@ -328,7 +331,7 @@ public class MatchIndex {
   /**
    * The length of the value element of the element starting at elementStartPos.
    *
-   * @param elementStartPos Starting positon of element to process
+   * @param elementStartPos Starting position of element to process
    * @return The length of the value section of this element.
    */
   private int getValueLength(int elementStartPos) {
@@ -341,7 +344,7 @@ public class MatchIndex {
   /**
    * The length of the children section of the element starting at elementStartPos.
    *
-   * @param elementStartPos Starting positon of element to process
+   * @param elementStartPos Starting position of element to process
    * @return The length of the children section of this element.
    */
   private int getChildrenLength(int elementStartPos) {
@@ -353,7 +356,7 @@ public class MatchIndex {
   }
 
   /**
-   * @param elementStartPos
+   * @param elementStartPos Starting position of element to process
    * @return The match index for this element. It is either the match index or MAX_SHORT if no
    * match.
    */

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTests.kt
@@ -12,29 +12,29 @@ class DeepLinkEntryTests {
     private val cpsFirstPathSegment = DeepLinkEntry("scheme://host/<config>/two/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
 
     @Test fun testSameness(){
-        assertTrue(concrete.moreConcreteThan(concrete) == 0)
-        assertTrue(parmSecondPathElement.moreConcreteThan(parmSecondPathElement) == 0)
-        assertTrue(parmFirstPathElement.moreConcreteThan(parmFirstPathElement) == 0)
-        assertTrue(cpsSecondPathSegment.moreConcreteThan(cpsSecondPathSegment) == 0)
-        assertTrue(cpsFirstPathSegment.moreConcreteThan(cpsFirstPathSegment) == 0)
+        assertTrue(concrete.compareTo(concrete) == 0)
+        assertTrue(parmSecondPathElement.compareTo(parmSecondPathElement) == 0)
+        assertTrue(parmFirstPathElement.compareTo(parmFirstPathElement) == 0)
+        assertTrue(cpsSecondPathSegment.compareTo(cpsSecondPathSegment) == 0)
+        assertTrue(cpsFirstPathSegment.compareTo(cpsFirstPathSegment) == 0)
     }
 
     @Test fun testEarlierLaterPlaceholder(){
-        assertTrue(parmSecondPathElement.moreConcreteThan(parmFirstPathElement) == 1)
-        assertTrue(parmFirstPathElement.moreConcreteThan(parmSecondPathElement) == -1)
-        assertTrue(parmSecondPathElement.moreConcreteThan(cpsFirstPathSegment) == 1)
-        assertTrue(parmFirstPathElement.moreConcreteThan(cpsSecondPathSegment) == -1)
+        assertTrue(parmSecondPathElement.compareTo(parmFirstPathElement) == 1)
+        assertTrue(parmFirstPathElement.compareTo(parmSecondPathElement) == -1)
+        assertTrue(parmSecondPathElement.compareTo(cpsFirstPathSegment) == 1)
+        assertTrue(parmFirstPathElement.compareTo(cpsSecondPathSegment) == -1)
     }
 
     @Test fun testEarlierLaterCps(){
-        assertTrue(cpsSecondPathSegment.moreConcreteThan(cpsFirstPathSegment) == 1)
-        assertTrue(cpsFirstPathSegment.moreConcreteThan(cpsSecondPathSegment) == -1)
-        assertTrue(cpsSecondPathSegment.moreConcreteThan(parmFirstPathElement) == 1)
-        assertTrue(cpsFirstPathSegment.moreConcreteThan(parmSecondPathElement) == -1)
+        assertTrue(cpsSecondPathSegment.compareTo(cpsFirstPathSegment) == 1)
+        assertTrue(cpsFirstPathSegment.compareTo(cpsSecondPathSegment) == -1)
+        assertTrue(cpsSecondPathSegment.compareTo(parmFirstPathElement) == 1)
+        assertTrue(cpsFirstPathSegment.compareTo(parmSecondPathElement) == -1)
     }
 
     @Test fun testPlaceholderWinOverCps(){
-        assertTrue(cpsSecondPathSegment.moreConcreteThan(parmSecondPathElement) == -1)
-        assertTrue(parmSecondPathElement.moreConcreteThan(cpsSecondPathSegment) == 1)
+        assertTrue(cpsSecondPathSegment.compareTo(parmSecondPathElement) == -1)
+        assertTrue(parmSecondPathElement.compareTo(cpsSecondPathSegment) == 1)
     }
 }

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTests.kt
@@ -1,0 +1,40 @@
+package com.airbnb.deeplinkdispatch
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeepLinkEntryTests {
+
+    private val concrete = DeepLinkEntry("scheme://host/one/two/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
+    private val parmSecondPathElement = DeepLinkEntry("scheme://host/one/{param}/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
+    private val parmFirstPathElement = DeepLinkEntry("scheme://host/{param}/two/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
+    private val cpsSecondPathSegment = DeepLinkEntry("scheme://host/one/<config>/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
+    private val cpsFirstPathSegment = DeepLinkEntry("scheme://host/<config>/two/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
+
+    @Test fun testSameness(){
+        assertTrue(concrete.moreConcreteThan(concrete) == 0)
+        assertTrue(parmSecondPathElement.moreConcreteThan(parmSecondPathElement) == 0)
+        assertTrue(parmFirstPathElement.moreConcreteThan(parmFirstPathElement) == 0)
+        assertTrue(cpsSecondPathSegment.moreConcreteThan(cpsSecondPathSegment) == 0)
+        assertTrue(cpsFirstPathSegment.moreConcreteThan(cpsFirstPathSegment) == 0)
+    }
+
+    @Test fun testEarlierLaterPlaceholder(){
+        assertTrue(parmSecondPathElement.moreConcreteThan(parmFirstPathElement) == 1)
+        assertTrue(parmFirstPathElement.moreConcreteThan(parmSecondPathElement) == -1)
+        assertTrue(parmSecondPathElement.moreConcreteThan(cpsFirstPathSegment) == 1)
+        assertTrue(parmFirstPathElement.moreConcreteThan(cpsSecondPathSegment) == -1)
+    }
+
+    @Test fun testEarlierLaterCps(){
+        assertTrue(cpsSecondPathSegment.moreConcreteThan(cpsFirstPathSegment) == 1)
+        assertTrue(cpsFirstPathSegment.moreConcreteThan(cpsSecondPathSegment) == -1)
+        assertTrue(cpsSecondPathSegment.moreConcreteThan(parmFirstPathElement) == 1)
+        assertTrue(cpsFirstPathSegment.moreConcreteThan(parmSecondPathElement) == -1)
+    }
+
+    @Test fun testPlaceholderWinOverCps(){
+        assertTrue(cpsSecondPathSegment.moreConcreteThan(parmSecondPathElement) == -1)
+        assertTrue(parmSecondPathElement.moreConcreteThan(cpsSecondPathSegment) == 1)
+    }
+}

--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -34,4 +34,7 @@ android {
     targetSdkVersion androidConfig.compileSdkVersion
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
+  testOptions {
+    unitTests.returnDefaultValues = true
+  }
 }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.app.TaskStackBuilder;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
@@ -28,6 +29,7 @@ public class BaseDeepLinkDelegate {
 
   protected final List<? extends BaseRegistry> registries;
 
+  @Nullable
   protected final ErrorHandler errorHandler;
   /**
    * <p>Mapping of values for DLD to substitute for annotation-declared configurablePathSegments.
@@ -259,7 +261,7 @@ public class BaseDeepLinkDelegate {
     Collections.sort(entryIdxMatches);
     if (entryIdxMatches.get(0).compareTo(entryIdxMatches.get(1)) == 0) {
       if (errorHandler != null) {
-        errorHandler.duplicateMatch(entryIdxMatches.subList(0, 2));
+        errorHandler.duplicateMatch(uriString, entryIdxMatches.subList(0, 2));
       }
       Log.w(TAG, "More than one match with the same concreteness!! ("
         + entryIdxMatches.get(0).toString() + ") vs. (" + entryIdxMatches.get(1).toString() + ")");

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
@@ -1,5 +1,5 @@
 package com.airbnb.deeplinkdispatch
 
 interface ErrorHandler {
-    fun duplicateMatch(duplicatedMatches: List<DeepLinkEntry>)
+    fun duplicateMatch(uriString: String, duplicatedMatches: List<DeepLinkEntry>)
 }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
@@ -1,0 +1,5 @@
+package com.airbnb.deeplinkdispatch
+
+interface ErrorHandler {
+    fun duplicateMatch(duplicatedMatches: List<DeepLinkEntry>)
+}

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.java
@@ -1,13 +1,14 @@
 package com.airbnb.deeplinkdispatch;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,7 +20,7 @@ public class BaseDeepLinkDelegateTest {
   @Test
   public void testDispatchNullActivity() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    TestDeepLinkDelegate testDelegate = getOneRegistryTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}), null);
     String message = null;
     try {
       testDelegate.dispatchFrom(null);
@@ -33,7 +34,7 @@ public class BaseDeepLinkDelegateTest {
   @Test
   public void testDispatchNullActivityNullIntent() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    TestDeepLinkDelegate testDelegate = getOneRegistryTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}), null);
     String message = null;
     try {
       testDelegate.dispatchFrom(null, null);
@@ -47,7 +48,7 @@ public class BaseDeepLinkDelegateTest {
   @Test
   public void testDispatchNullIntent() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    TestDeepLinkDelegate testDelegate = getOneRegistryTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}), null);
 
     Activity activity = mock(Activity.class);
     when(activity.getIntent())
@@ -66,7 +67,7 @@ public class BaseDeepLinkDelegateTest {
   @Test
   public void testDispatchNonNullActivityNullIntent() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    TestDeepLinkDelegate testDelegate = getOneRegistryTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}), null);
 
     Activity activity = mock(Activity.class);
     when(activity.getIntent())
@@ -85,7 +86,7 @@ public class BaseDeepLinkDelegateTest {
   @Test
   public void testCreateResultAllNull() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    TestDeepLinkDelegate testDelegate = getOneRegistryTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}), null);
 
     String message = null;
     try {
@@ -100,7 +101,7 @@ public class BaseDeepLinkDelegateTest {
   @Test
   public void testCreateResultNullIntent() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    TestDeepLinkDelegate testDelegate = getOneRegistryTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}), null);
 
     Activity activity = mock(Activity.class);
     when(activity.getIntent())
@@ -119,7 +120,7 @@ public class BaseDeepLinkDelegateTest {
   @Test
   public void testCreateResultAllNullData() {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
-    TestDeepLinkDelegate testDelegate = getTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}));
+    TestDeepLinkDelegate testDelegate = getOneRegistryTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}), null);
 
     Intent intent = mock(Intent.class);
     when(intent.getData())
@@ -132,6 +133,85 @@ public class BaseDeepLinkDelegateTest {
 
     assertThat(result).isEqualTo(new DeepLinkResult(
       false, null, "No Uri in given activity's intent.", null, null, null));
+  }
+
+  @Test
+  public void testErrorHanderWithDuplicateMartch() {
+    String deeplinkUrl = "airbnb://foo/{bar}";
+    DeepLinkEntry entry = deepLinkEntry(deeplinkUrl);
+
+    Uri uri = mock(Uri.class);
+    when(uri.toString())
+      .thenReturn(deeplinkUrl);
+    Intent intent = mock(Intent.class);
+    when(intent.getData())
+      .thenReturn(uri);
+    Context appContext = mock(Context.class);
+    Activity activity = mock(Activity.class);
+    when(activity.getIntent())
+      .thenReturn(intent);
+    when(activity.getApplicationContext())
+      .thenReturn(appContext);
+
+    TestErrorHandler errorHandler = new TestErrorHandler();
+    TestDeepLinkDelegate testDelegate = getTwoRegistriesTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry}), Arrays.asList(new DeepLinkEntry[]{entry}), errorHandler);
+    DeepLinkResult result = testDelegate.dispatchFrom(activity, intent);
+
+    assertThat(errorHandler.duplicatedMatchCalled()).isTrue();
+    assertThat(errorHandler.getDuplicatedMatches()).isNotNull();
+    assertThat(errorHandler.getDuplicatedMatches().size()).isEqualTo(2);
+    assertThat(errorHandler.getDuplicatedMatches().get(0)).isEqualTo(entry);
+    assertThat(errorHandler.getDuplicatedMatches().get(1)).isEqualTo(entry);
+
+    assertThat(result.getDeepLinkEntry().equals(entry));
+  }
+
+  @Test
+  public void testErrorHandlerNotGettingCalled() {
+    String deeplinkUrl1 = "airbnb://foo/{bar}";
+    String deeplinkUrl2 = "airbnb://bar/{foo}";
+    DeepLinkEntry entry1 = deepLinkEntry(deeplinkUrl1);
+    DeepLinkEntry entry2 = deepLinkEntry(deeplinkUrl2);
+
+    Uri uri = mock(Uri.class);
+    when(uri.toString())
+      .thenReturn(deeplinkUrl2);
+    Intent intent = mock(Intent.class);
+    when(intent.getData())
+      .thenReturn(uri);
+    Context appContext = mock(Context.class);
+    Activity activity = mock(Activity.class);
+    when(activity.getIntent())
+      .thenReturn(intent);
+    when(activity.getApplicationContext())
+      .thenReturn(appContext);
+
+    TestErrorHandler errorHandler = new TestErrorHandler();
+    TestDeepLinkDelegate testDelegate = getTwoRegistriesTestDelegate(Arrays.asList(new DeepLinkEntry[]{entry1}), Arrays.asList(new DeepLinkEntry[]{entry2}), errorHandler);
+    DeepLinkResult result = testDelegate.dispatchFrom(activity, intent);
+
+    assertThat(errorHandler.duplicatedMatchCalled()).isFalse();
+    assertThat(result.getDeepLinkEntry().equals(entry2));
+  }
+
+  class TestErrorHandler implements ErrorHandler {
+
+    List<DeepLinkEntry> duplicatedMatches = null;
+    boolean duplicateMatchCalled = false;
+
+    public List<DeepLinkEntry> getDuplicatedMatches() {
+      return duplicatedMatches;
+    }
+
+    public boolean duplicatedMatchCalled() {
+      return duplicateMatchCalled;
+    }
+
+    @Override
+    public void duplicateMatch(@NotNull List<DeepLinkEntry> duplicatedMatches) {
+      this.duplicatedMatches = duplicatedMatches;
+      duplicateMatchCalled = true;
+    }
   }
 
   private static DeepLinkEntry deepLinkEntry(String uri) {
@@ -155,24 +235,27 @@ public class BaseDeepLinkDelegateTest {
     }
 
     @NotNull
-    private static byte[] getSearchIndex(List<DeepLinkEntry> registry) {
+    private static byte[] getSearchIndex(List<DeepLinkEntry> deepLinkEntries) {
       Root trieRoot = new Root();
-      for (int i = 0; i < registry.size(); i++) {
-        trieRoot.addToTrie(i, DeepLinkUri.parse(registry.get(i).getUriTemplate()), registry.get(i).getActivityClass().toString(), registry.get(i).getMethod());
+      for (int i = 0; i < deepLinkEntries.size(); i++) {
+        trieRoot.addToTrie(i, DeepLinkUri.parse(deepLinkEntries.get(i).getUriTemplate()), deepLinkEntries.get(i).getActivityClass().toString(), deepLinkEntries.get(i).getMethod());
       }
       return trieRoot.toUByteArray();
     }
   }
 
-  private static TestDeepLinkDelegate getTestDelegate(List<DeepLinkEntry> entries) {
-    return new TestDeepLinkDelegate(Arrays.asList(getTestRegistry(entries)));
+  private static TestDeepLinkDelegate getTwoRegistriesTestDelegate(List<DeepLinkEntry> entriesFirstRegistry, List<DeepLinkEntry> entriesSecondRegistry, ErrorHandler errorHandler) {
+    return new TestDeepLinkDelegate(Arrays.asList(getTestRegistry(entriesFirstRegistry), getTestRegistry(entriesSecondRegistry)), errorHandler);
+  }
+
+  private static TestDeepLinkDelegate getOneRegistryTestDelegate(List<DeepLinkEntry> entries, ErrorHandler errorHandler) {
+    return new TestDeepLinkDelegate(Arrays.asList(getTestRegistry(entries)), errorHandler);
   }
 
   private static class TestDeepLinkDelegate extends BaseDeepLinkDelegate {
 
-    public TestDeepLinkDelegate(List<? extends BaseRegistry> registries) {
-      super(registries);
+    public TestDeepLinkDelegate(List<? extends BaseRegistry> registries, ErrorHandler errorHandler) {
+      super(registries, errorHandler);
     }
   }
-
 }

--- a/sample-library/src/main/java/com/airbnb/deeplinkdispatch/sample/library/LibraryActivity.java
+++ b/sample-library/src/main/java/com/airbnb/deeplinkdispatch/sample/library/LibraryActivity.java
@@ -1,16 +1,22 @@
 package com.airbnb.deeplinkdispatch.sample.library;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.util.Log;
 import android.widget.Toast;
 
 import com.airbnb.deeplinkdispatch.DeepLink;
 
 @DeepLink("http://example.com/library")
 public class LibraryActivity extends AppCompatActivity {
+
+  private static final String TAG = LibraryActivity.class.getSimpleName();
+
   @SuppressLint("RestrictedApi")
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -19,5 +25,21 @@ public class LibraryActivity extends AppCompatActivity {
       Toast.makeText(this, "Got deep link " + intent.getStringExtra(DeepLink.URI),
           Toast.LENGTH_SHORT).show();
     }
+  }
+
+  /**
+   * This method is a more concrete match for the URI dld://host/somePathOne/somePathTwo/somePathThree
+   * to a annotated method in `sample` that is annotated with
+   * @DeepLink("dld://host/somePathOne/{param1}/somePathThree") and thus will never be picked over
+   * this method when matching.
+   *
+   * @param context
+   * @param bundle
+   * @return
+   */
+  @DeepLink("placeholder://host/somePathOne/somePathTwo/somePathThree")
+  public static Intent moreConcreteMatch(Context context, Bundle bundle) {
+    Log.d(TAG, "matched more concrete url in sample-library project.");
+    return new Intent(context, LibraryActivity.class);
   }
 }

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/DeepLinkActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/DeepLinkActivity.java
@@ -9,16 +9,25 @@ import com.airbnb.deeplinkdispatch.sample.benchmarkable.BenchmarkDeepLinkModuleR
 import com.airbnb.deeplinkdispatch.sample.library.LibraryDeepLinkModule;
 import com.airbnb.deeplinkdispatch.sample.library.LibraryDeepLinkModuleRegistry;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @DeepLinkHandler({SampleModule.class, LibraryDeepLinkModule.class, BenchmarkDeepLinkModule.class})
 public class DeepLinkActivity extends Activity {
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-//    Debug.startMethodTracing("deeplink.trace",90000000);
-        DeepLinkDelegate deepLinkDelegate = new DeepLinkDelegate(
-                new SampleModuleRegistry(), new LibraryDeepLinkModuleRegistry(), new BenchmarkDeepLinkModuleRegistry());
-        deepLinkDelegate.dispatchFrom(this);
-//    Debug.stopMethodTracing();
-        finish();
-    }
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    //    Debug.startMethodTracing("deeplink.trace",90000000);
+    Map configurablePlaceholdersMap = new HashMap();
+    configurablePlaceholdersMap.put("configPathOne", "somePathThree");
+    configurablePlaceholdersMap.put("configurable-path-segment-one", "");
+    configurablePlaceholdersMap.put("configurable-path-segment", "");
+    configurablePlaceholdersMap.put("configurable-path-segment-two", "");
+    configurablePlaceholdersMap.put("configPathOne", "somePathOne");
+    DeepLinkDelegate deepLinkDelegate = new DeepLinkDelegate(
+      new SampleModuleRegistry(), new LibraryDeepLinkModuleRegistry(), new BenchmarkDeepLinkModuleRegistry(), configurablePlaceholdersMap);
+    deepLinkDelegate.dispatchFrom(this);
+    //    Debug.stopMethodTracing();
+    finish();
+  }
 }

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
@@ -122,6 +122,24 @@ public class MainActivity extends AppCompatActivity {
     return new Intent(context, MainActivity.class).setAction(ACTION_DEEP_LINK_COMPLEX);
   }
 
+  /**
+   * This method is a less concrete match for the URI dld://host/somePathOne/somePathTwo/somePathThree
+   * to a annotated method in `sample-library` that is annotated with
+   * @DeepLink("dld://host/somePathOne/somePathTwo/somePathThree") and thus will always be picked over
+   * this method when matching.
+   *
+   * @param context
+   * @param bundle
+   * @return
+   */
+  @DeepLink("placeholder://host/somePathOne/{param1}/somePathThree")
+  public static Intent lessConcreteMatch(Context context, Bundle bundle) {
+    if (bundle != null && bundle.containsKey("param1")) {
+      Log.d(TAG, "matched less concrete url in sample project :" + bundle.getString("param1"));
+    }
+    return new Intent(context, MainActivity.class).setAction(ACTION_DEEP_LINK_METHOD);
+  }
+
   private void showToast(String message) {
     Toast.makeText(this, "Deep Link: " + message, Toast.LENGTH_SHORT).show();
   }

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import com.airbnb.deeplinkdispatch.DeepLink;
 import com.airbnb.deeplinkdispatch.DeepLinkDispatch;
 import com.airbnb.deeplinkdispatch.sample.benchmarkable.BenchmarkDeepLinkModuleRegistry;
+import com.airbnb.deeplinkdispatch.sample.library.LibraryActivity;
 import com.airbnb.deeplinkdispatch.sample.library.LibraryDeepLinkModuleRegistry;
 
 import org.junit.Test;
@@ -174,16 +175,24 @@ public class MainActivityTest {
 
   @Test
   public void testSupportsUri() throws Exception {
+    Map<String, String> configurablePathSegmentReplacements = new HashMap<>();
+    configurablePathSegmentReplacements.put("configurable-path-segment", "obamaOs");
+    configurablePathSegmentReplacements.put("configurable-path-segment-one", "belong");
+    configurablePathSegmentReplacements.put("configurable-path-segment-two", "anywhere");
     DeepLinkDelegate deepLinkDelegate = new DeepLinkDelegate(new SampleModuleRegistry(),
-      new LibraryDeepLinkModuleRegistry(), new BenchmarkDeepLinkModuleRegistry());
+      new LibraryDeepLinkModuleRegistry(), new BenchmarkDeepLinkModuleRegistry(), configurablePathSegmentReplacements);
     assertThat(deepLinkDelegate.supportsUri("dld://classDeepLink"), equalTo(true));
     assertThat(deepLinkDelegate.supportsUri("some://weirdNonExistentUri"), equalTo(false));
   }
 
   @Test
   public void testSameLengthComponentsMismatch() throws Exception {
+    Map<String, String> configurablePathSegmentReplacements = new HashMap<>();
+    configurablePathSegmentReplacements.put("configurable-path-segment", "obamaOs");
+    configurablePathSegmentReplacements.put("configurable-path-segment-one", "belong");
+    configurablePathSegmentReplacements.put("configurable-path-segment-two", "anywhere");
     DeepLinkDelegate deepLinkDelegate = new DeepLinkDelegate(new SampleModuleRegistry(),
-      new LibraryDeepLinkModuleRegistry(), new BenchmarkDeepLinkModuleRegistry());
+      new LibraryDeepLinkModuleRegistry(), new BenchmarkDeepLinkModuleRegistry(), configurablePathSegmentReplacements);
     assertThat(deepLinkDelegate.supportsUri("dld://classDeepLink"), equalTo(true));
     assertThat(deepLinkDelegate.supportsUri("dld://classDeepLinx"), equalTo(false));
   }
@@ -243,5 +252,16 @@ public class MainActivityTest {
       new LibraryDeepLinkModuleRegistry(), new BenchmarkDeepLinkModuleRegistry(), configurablePathSegmentReplacements);
     assertThat(deepLinkDelegate.supportsUri("https://www.example.com/anywhere/belong/foo"), equalTo(false));
     assertThat(deepLinkDelegate.supportsUri("https://www.example.com/belong/anywhere/foo"), equalTo(true));
+  }
+
+  @Test
+  public void testMoreConcreteMach() {
+    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("placeholder://host/somePathOne/somePathTwo/somePathThree"));
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+      .create().get();
+    ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
+    Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
+    assertThat(launchedIntent.getComponent(),
+      equalTo(new ComponentName(deepLinkActivity, LibraryActivity.class)));
   }
 }


### PR DESCRIPTION
Changed code so that all registries (there is one registry per module) will be checked for matches and the same rule (`concrete > placeholder > configurable path segment` rule is applied for all matches.

This is accomplished by sorting the list of matched url templates by "concreteness" (based on where it has placeholders/configurable path segments) The same way this is done while matching inside an index

- Added tests for DeeplinkEntry "concreteness" comparator
- Added tests for (other than before) matching more concrete match in Library (that is matched after the sample app gets matched)

Require the mapping for configurable path segments given to the `DeeplinkDelegate` to not just match the configurable path segments when given but also when not given.