### PR TITLE
Update to AGP 4.0.

### DIFF
--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -27,7 +27,6 @@ checkstyle {
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     minSdkVersion androidConfig.minSdkVersion

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,9 +8,8 @@ def versions = [
 
 ext.versions = versions
 ext.androidConfig = [
-    agpVersion                          : '3.6.3',
+    agpVersion                          : '4.0.0',
     compileSdkVersion                   : 29,
-    buildToolsVersion                   : '29.0.2',
     minSdkVersion                       : 16,
     targetSdkVersion                    : 29
 ]

--- a/sample-benchmark/build.gradle
+++ b/sample-benchmark/build.gradle
@@ -4,7 +4,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion androidConfig.compileSdkVersion
-    buildToolsVersion androidConfig.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidConfig.minSdkVersion

--- a/sample-benchmarkable-library/build.gradle
+++ b/sample-benchmarkable-library/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     minSdkVersion androidConfig.minSdkVersion

--- a/sample-library/build.gradle
+++ b/sample-library/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     minSdkVersion androidConfig.minSdkVersion

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -12,7 +12,6 @@ checkstyle {
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     applicationId "com.airbnb.deeplinkdispatch.sample"


### PR DESCRIPTION
Build tools are now bound to AGP version.