### PR TITLE
Fix placeholder match

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -80,7 +80,7 @@ public class MatchIndex {
 
   /**
    * Match a given {@link com.airbnb.deeplinkdispatch.DeepLinkUri} (given as a List of
-   * {@link UrlElement} aginst this serach index.
+   * {@link UrlElement} against thissearchh index.
    * Will return an instance of {@link Match} if a match was found or null if there wasn't.
    *
    * @param elements The {@link UrlElement} list of
@@ -90,13 +90,13 @@ public class MatchIndex {
    *                     to collect the set of placeholders and their values as
    *                     the {@link com.airbnb.deeplinkdispatch.DeepLinkUri} is recursively
    *                     processed.
-   * @param elementIndex The index of the elemnt currently processed in the elements list above.
+   * @param elementIndex The index of the element currently processed in the elements list above.
    * @param elementStartPosition The index of the start position of the current element int he
    *                             byte array search index.
    * @param parentBoundryPos The last element that is still part of the parent element. While
    *                         looking at children of a current element that is the last element of
    *                         the last child.
-   * @param pathSegmentReplacements  A map of configuralbe path segment replacements and their
+   * @param pathSegmentReplacements  A map of configurable path segment replacements and their
    *                                 values.
    * @return An instance of {@link Match} if a match was found null if it wasn't.
    */
@@ -144,12 +144,10 @@ public class MatchIndex {
           }
         } else {
           int matchIndex = getMatchIndex(currentElementStartPosition);
-          // Url is a partial match.
-          if (matchIndex == NO_MATCH) {
-            return null;
+          if (matchIndex != NO_MATCH) {
+            match = new Match(matchIndex, placeholdersOutput == null
+              ? new HashMap<String, String>(0) : placeholdersOutput);
           }
-          match = new Match(matchIndex, placeholdersOutput == null
-            ? new HashMap<String, String>(0) : placeholdersOutput);
         }
       }
       if (match != null) {

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -80,7 +80,7 @@ public class MatchIndex {
 
   /**
    * Match a given {@link com.airbnb.deeplinkdispatch.DeepLinkUri} (given as a List of
-   * {@link UrlElement} against thissearchh index.
+   * {@link UrlElement} against this searchh index.
    * Will return an instance of {@link Match} if a match was found or null if there wasn't.
    *
    * @param elements The {@link UrlElement} list of

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -31,7 +31,7 @@ public class DeepLinkEntryTest {
 
   /**
    * This test makes sure that both version of the parametrized strings are matched correctly.
-   * As mach groups are sorted alphabetically in the index we need to make sure that the
+   * As match groups are sorted alphabetically in the index we need to make sure that the
    * shorter one is in the index behind the longer one (as otherwise the test would match
    * correctly anyway)
    */

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -29,6 +29,33 @@ public class DeepLinkEntryTest {
     assertThat(parameters.get("param2")).isEqualTo("alice");
   }
 
+  /**
+   * This test makes sure that both version of the parametrized strings are matched correctly.
+   * As mach groups are sorted alphabetically in the index we need to make sure that the
+   * shorter one is in the index behind the longer one (as otherwise the test would match
+   * correctly anyway)
+   */
+  @Test public void testOneAndTwoParamsSubPath() {
+    DeepLinkEntry entryOneParams = deepLinkEntry("airbnb://test/path/{param3}");
+    DeepLinkEntry entryTwoParams = deepLinkEntry("airbnb://test/path/{param2}/{param1}");
+    TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entryTwoParams, entryOneParams}));
+
+    String url2Params = "airbnb://test/path/bob/alice";
+    DeepLinkEntry matchTwo = testRegistry.idxMatch(DeepLinkUri.parse(url2Params));
+    assertThat(matchTwo).isNotNull();
+    Map<String, String> parameters2 = matchTwo.getParameters(DeepLinkUri.parse(url2Params));
+    assertThat(parameters2.get("param2")).isEqualTo("bob");
+    assertThat(parameters2.get("param1")).isEqualTo("alice");
+    assertThat(parameters2.size()).isEqualTo(2);
+
+    String url1Param = "airbnb://test/path/eve";
+    DeepLinkEntry matchOne = testRegistry.idxMatch(DeepLinkUri.parse(url1Param));
+    Map<String, String> parameters1 = matchOne.getParameters(DeepLinkUri.parse(url1Param));
+    assertThat(matchOne).isNotNull();
+    assertThat(parameters1.get("param3")).isEqualTo("eve");
+    assertThat(parameters1.size()).isEqualTo(1);
+  }
+
   @Test public void testParamWithSpecialCharacters() throws Exception {
     DeepLinkEntry entry = deepLinkEntry("airbnb://foo/{bar}");
     TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,16 +2,16 @@ def versions = [
     kotlinVersion                : '1.3.72',
     appCompatVersion             : '1.1.0',
     localBroadcastManagerVersion : '1.0.0',
-    roboelectricVersion          : '4.3.1',
+    roboelectricVersion          : '4.5.1',
     benchmarkVersion             : '1.0.0'
 ]
 
 ext.versions = versions
 ext.androidConfig = [
-    agpVersion                          : '4.0.0',
-    compileSdkVersion                   : 29,
+    agpVersion                          : '4.1.2',
+    compileSdkVersion                   : 30,
     minSdkVersion                       : 16,
-    targetSdkVersion                    : 29
+    targetSdkVersion                    : 30
 ]
 
 ext.deps = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip


### PR DESCRIPTION
Because of the way the index is sorted two deeplinks that are only differentiated by the number of placeholders in the match like:

`app://host/{a}{b}`and
`app://host/{c}`

would have the shorter one not match if the placeholder in question is lexicographic after the ones in the longer one.

This e.g. would have worked:

`app://host/{c}{b}`and
`app://host/{a}`

This fixes this by checking all elements on on one level of the trie before reporting no match.

This fixes https://github.com/airbnb/DeepLinkDispatch/issues/303