### PR TITLE
Change default visibility of annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,10 @@ annotation. A popular use case for this is with web versus app deep links:
 ```java
 // Prefix all app deep link URIs with "app://airbnb"
 @DeepLinkSpec(prefix = { "app://airbnb" })
-@Retention(RetentionPolicy.CLASS)
+// When using tools like Dexguard we require these annotations to still be inside the .dex files
+// produced by D8 but because of this bug https://issuetracker.google.com/issues/168524920 they
+// are not so we need to mark them as RetentionPolicy.RUNTIME.
+@Retention(RetentionPolicy.RUNTIME)
 public @interface AppDeepLink {
   String[] value();
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLink.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLink.java
@@ -27,7 +27,10 @@ import java.lang.annotation.Target;
  * </code></pre>
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RetentionPolicy.CLASS)
+// When using tools like Dexguard we require these annotations to still be inside the .dex files
+// produced by D8 but because of this bug https://issuetracker.google.com/issues/168524920 they
+// are not so we need to mark them as RetentionPolicy.RUNTIME.
+@Retention(RetentionPolicy.RUNTIME)
 public @interface DeepLink {
   String IS_DEEP_LINK = "is_deep_link_flag";
   String URI = "deep_link_uri";

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkSpec.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkSpec.java
@@ -39,7 +39,10 @@ import java.lang.annotation.Target;
  * </ul>
  */
 @Target({ ElementType.ANNOTATION_TYPE })
-@Retention(RetentionPolicy.CLASS)
+// When using tools like Dexguard we require these annotations to still be inside the .dex files
+// produced by D8 but because of this bug https://issuetracker.google.com/issues/168524920 they
+// are not so we need to mark them as RetentionPolicy.RUNTIME.
+@Retention(RetentionPolicy.RUNTIME)
 public @interface DeepLinkSpec {
   String[] prefix();
 }

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/WebDeepLink.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/WebDeepLink.java
@@ -2,7 +2,14 @@ package com.airbnb.deeplinkdispatch.sample;
 
 import com.airbnb.deeplinkdispatch.DeepLinkSpec;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 @DeepLinkSpec(prefix = { "http://airbnb.com", "https://airbnb.com" })
+// When using tools like Dexguard we require these annotations to still be inside the .dex files
+// produced by D8 but because of this bug https://issuetracker.google.com/issues/168524920 they
+// are not so we need to mark them as RetentionPolicy.RUNTIME.
+@Retention(RetentionPolicy.RUNTIME)
 public @interface WebDeepLink {
   String[] value();
 }


### PR DESCRIPTION
- Make annotations RUNTIME visible to better work with latest Dexguard.

This also addresses: https://github.com/airbnb/DeepLinkDispatch/issues/299