### PR TITLE
Embed match info into index

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,24 +371,23 @@ kapt {
 
 Starting with v5 DeeplinkDispatch is designed to be very fast in resolving deep links even if there are a lot of them. To ensure we do not regress from this benchmark tests using [`androidx.benchmark`](https://developer.android.com/studio/profile/benchmark#top_of_page) were added.
 
-It is testing the `ScaleTestActivity` in the `sample-benchmarkable-library` which has 2000 deep links. For those on a Pixel 2 running Android 10 we expect the following results:
+It is testing the `ScaleTestActivity` in the `sample-benchmarkable-library` which has 2000 deep links. For those on a Pixel 2 running Android 11 we expect the following results:
 
 ```text
 Started running tests
-Timed out waiting for process to appear on google-pixel_2-FA7AW1A04466.
-benchmark:        11,520 ns DeeplinkBenchmarks.match1
-benchmark:       241,406 ns DeeplinkBenchmarks.match500
-benchmark:    12,067,970 ns DeeplinkBenchmarks.newRegistry
-benchmark:        12,076 ns DeeplinkBenchmarks.match1000
-benchmark:       140,000 ns DeeplinkBenchmarks.match1500
-benchmark:       273,230 ns DeeplinkBenchmarks.match2000
-benchmark:       148,750 ns DeeplinkBenchmarks.createResultDeeplink1
-benchmark:        11,375 ns DeeplinkBenchmarks.parseDeeplinkUrl
 
+benchmark:        11,716 ns DeeplinkBenchmarks.match1
+benchmark:       139,375 ns DeeplinkBenchmarks.match500
+benchmark:     2,163,907 ns DeeplinkBenchmarks.newRegistry
+benchmark:        23,035 ns DeeplinkBenchmarks.match1000
+benchmark:       152,969 ns DeeplinkBenchmarks.match1500
+benchmark:       278,906 ns DeeplinkBenchmarks.match2000
+benchmark:       162,604 ns DeeplinkBenchmarks.createResultDeeplink1
+benchmark:        11,774 ns DeeplinkBenchmarks.parseDeeplinkUrl
 Tests ran to completion.
 ```
 
-As you can see it takes us about 11ms to create the registry with 2000 entries. A lookup can be done in sub 1ms usually and `createResult`, which includes the lookup for the `match1` case plus actually calling the method that was annotated, can be done in 0.2ms. 
+As you can see it takes us about 11ms to create the registry with 2000 entries. A lookup can be done in sub 1ms usually and `createResult`, which includes the lookup for the `match1` case plus actually calling the method that was annotated, can be done in under 0.2ms.
 
 The performance tests can be run from Android Studio or via gradle by running `./gradlew sample-benchmark:connectedCheck` (with a device connected). The outoput can be found in `sample-benchmark/build/outputs/connected_android_test_additional_output/`.
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ benchmark:        11,774 ns DeeplinkBenchmarks.parseDeeplinkUrl
 Tests ran to completion.
 ```
 
-As you can see it takes us about 11ms to create the registry with 2000 entries. A lookup can be done in sub 1ms usually and `createResult`, which includes the lookup for the `match1` case plus actually calling the method that was annotated, can be done in under 0.2ms.
+As you can see it takes us about 2ms to create the registry with 2000 entries. A lookup can be done in sub 1ms usually and `createResult`, which includes the lookup for the `match1` case plus actually calling the method that was annotated, can be done in under 0.2ms.
 
 The performance tests can be run from Android Studio or via gradle by running `./gradlew sample-benchmark:connectedCheck` (with a device connected). The outoput can be found in `sample-benchmark/build/outputs/connected_android_test_additional_output/`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://oss.sonatype.org/service/local/repositories/snapshots/content/" }
     }
     dependencies {
@@ -22,7 +22,7 @@ allprojects {
 
   repositories {
     google()
-    jcenter()
+      mavenCentral()
   }
 }
 

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/BaseRegistry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/BaseRegistry.kt
@@ -42,14 +42,12 @@ abstract class BaseRegistry(val registeredDeepLinks: List<DeepLinkEntry>,
         }
         // Generating a match list (list of elements in to be matched URL starting with an
         // (artificial) root.
-        val match = matchIndex.matchUri(SchemeHostAndPath(deepLinkUri).matchList,
-                null, 0, 0, matchIndex.length(),
+        return matchIndex.matchUri(deepLinkUri,
+                SchemeHostAndPath(deepLinkUri).matchList,
+                null,
+                0,
+                0,
+                matchIndex.length(),
                 pathSegmentReplacements)
-        if (match != null) {
-            val matchedEntry = registeredDeepLinks[match.matchIndex]
-            matchedEntry.setParameters(deepLinkUri, match.parameterMap)
-            return matchedEntry
-        }
-        return null
     }
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/BaseRegistry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/BaseRegistry.kt
@@ -17,8 +17,7 @@ import com.airbnb.deeplinkdispatch.base.Utils
  * [BaseDeepLinkDelegate]. The correspondent's presence will be validated at runtime by
  * [com.airbnb.deeplinkdispatch.ValidationUtilsKt.validateConfigurablePathSegmentReplacements].
  */
-abstract class BaseRegistry(val registeredDeepLinks: List<DeepLinkEntry>,
-                            matchIndexArray: ByteArray,
+abstract class BaseRegistry(matchIndexArray: ByteArray,
                             pathSegmentReplacementKeys: Array<String>) {
     val pathSegmentReplacementKeysInRegistry = Utils.toByteArraysList(pathSegmentReplacementKeys)
     private val matchIndex: MatchIndex = MatchIndex(matchIndexArray)

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
@@ -18,7 +18,6 @@ package com.airbnb.deeplinkdispatch
 import kotlin.math.min
 
 class DeepLinkEntry(val uriTemplate: String,
-                    val type: Type,
                     /**
                      * The class where the annotation corresponding to where an instance of DeepLinkEntry is declared.
                      */
@@ -64,7 +63,7 @@ class DeepLinkEntry(val uriTemplate: String,
     }
 
     override fun toString(): String {
-        return "uriTemplate: $uriTemplate type: $type activity: ${activityClass.simpleName} method: $method parameters: $parameterMap"
+        return "uriTemplate: $uriTemplate activity: ${activityClass.simpleName} method: $method parameters: $parameterMap"
     }
 
     /**
@@ -86,5 +85,27 @@ class DeepLinkEntry(val uriTemplate: String,
             }
             else -> 1
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DeepLinkEntry
+
+        if (uriTemplate != other.uriTemplate) return false
+        if (activityClass != other.activityClass) return false
+        if (method != other.method) return false
+        if (parameterMap != other.parameterMap) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = uriTemplate.hashCode()
+        result = 31 * result + activityClass.hashCode()
+        result = 31 * result + (method?.hashCode() ?: 0)
+        result = 31 * result + parameterMap.hashCode()
+        return result
     }
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/UrlTree.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/UrlTree.kt
@@ -154,34 +154,34 @@ data class PathSegment(override val id: String) : TreeNode(id = id, metadata = N
  * (2+url template length)+2+classname length+1+method name length method name
  */
 fun matchByteArray(match: UriMatch?): UByteArray {
-    return match?.let {
-        val uriTemplateByteArray = it.uriTemplate.toString().toByteArray(UTF_8).toUByteArray()
-        val classNameByteArray = it.annotatedClassFullyQualifiedName.toByteArray(UTF_8).toUByteArray()
-        val methodNameByteArray = it.annotatedMethod?.let { it.toByteArray(UTF_8).toUByteArray() }
-                ?: UByteArray(0)
-        UByteArray(MATCH_DATA_URL_TEMPLATE_LENGTH + uriTemplateByteArray.size
-                + MATCH_DATA_CLASS_LENGTH + classNameByteArray.size
-                + MATCH_DATA_METHOD_LENGTH + methodNameByteArray.size)
-                .apply {
-                    var position = 0
-                    // Uri template
-                    writeUShortAt(startIndex = 0, value = uriTemplateByteArray.size.toUShort())
-                    position += MATCH_DATA_URL_TEMPLATE_LENGTH
-                    uriTemplateByteArray.copyInto(destination = this, destinationOffset = position)
-                    position += uriTemplateByteArray.size
+    if (match == null) return UByteArray(0)
 
-                    // Class name
-                    writeUShortAt(startIndex = position, value = classNameByteArray.size.toUShort())
-                    position += MATCH_DATA_CLASS_LENGTH
-                    classNameByteArray.copyInto(destination = this, destinationOffset = position)
-                    position += classNameByteArray.size
+    val uriTemplateByteArray = match.uriTemplate.toByteArray(UTF_8).toUByteArray()
+    val classNameByteArray = match.annotatedClassFullyQualifiedName.toByteArray(UTF_8).toUByteArray()
+    val methodNameByteArray = match.annotatedMethod?.let { it.toByteArray(UTF_8).toUByteArray() }
+            ?: UByteArray(0)
+    return UByteArray(MATCH_DATA_URL_TEMPLATE_LENGTH + uriTemplateByteArray.size
+            + MATCH_DATA_CLASS_LENGTH + classNameByteArray.size
+            + MATCH_DATA_METHOD_LENGTH + methodNameByteArray.size)
+            .apply {
+                var position = 0
+                // Uri template
+                writeUShortAt(startIndex = 0, value = uriTemplateByteArray.size.toUShort())
+                position += MATCH_DATA_URL_TEMPLATE_LENGTH
+                uriTemplateByteArray.copyInto(destination = this, destinationOffset = position)
+                position += uriTemplateByteArray.size
 
-                    // method
-                    this.set(position, methodNameByteArray.size.toUByte())
-                    position += MATCH_DATA_METHOD_LENGTH
-                    if (methodNameByteArray.size > 0) methodNameByteArray.copyInto(destination = this, destinationOffset = position)
-                }
-    } ?: UByteArray(0)
+                // Class name
+                writeUShortAt(startIndex = position, value = classNameByteArray.size.toUShort())
+                position += MATCH_DATA_CLASS_LENGTH
+                classNameByteArray.copyInto(destination = this, destinationOffset = position)
+                position += classNameByteArray.size
+
+                // method
+                this.set(position, methodNameByteArray.size.toUByte())
+                position += MATCH_DATA_METHOD_LENGTH
+                if (methodNameByteArray.size > 0) methodNameByteArray.copyInto(destination = this, destinationOffset = position)
+            }
 }
 
 fun UByteArray.writeUIntAt(startIndex: Int, value: UInt) {

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/UrlTree.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/UrlTree.kt
@@ -10,7 +10,7 @@ import java.io.OutputStream
 import java.nio.charset.Charset
 import kotlin.text.Charsets.UTF_8
 
-data class UriMatch(val uri: DeepLinkUri, val matchId: Int, val annotatedElement: String, val annotatedMethod: String?)
+data class UriMatch(val uriTemplate: String, val matchId: Int, val annotatedClassFullyQualifiedName: String, val annotatedMethod: String?)
 
 @kotlin.ExperimentalUnsignedTypes
 open class TreeNode(open val id: String, internal val metadata: NodeMetadata) {
@@ -34,49 +34,64 @@ open class TreeNode(open val id: String, internal val metadata: NodeMetadata) {
 
     /**
      * Byte array format is:
-     * 0                                                    [NodeMetadata] flags; 1 byte
-     * 1                                                    length of value sub-array
-     * 2...5                                                length of node's children sub-array
-     * 6...7                                                match id
-     * 8..(8+value length)                                  actual value sub-array
-     * (8+value length)..((8+value length)+children length) actual children sub-array
+     * 0                                                      [NodeMetadata] flags; 1 byte
+     * 1                                                      length of value sub-array
+     * 2..3                                                   length of match sub-array
+     * 4...7                                                  length of node's children sub-array
+     * 8...9                                                  match id
+     * 10..(10+value length)                                  actual value sub-array
+     * (10+value length)..
+     * ((10+value length)+children length)                    match data (can be 0 length)
+     * (10+value length+match data length)..
+     * ((10+value length+match data length)+children length)  actual children sub-array
      */
     fun toUByteArray(): UByteArray {
         val childrenByteArrays: List<UByteArray> = generateChildrenByteArrays()
         val valueByteArray = serializedId().toByteArray(UTF_8).toUByteArray()
-        val header = generateHeader(metadata, valueByteArray, childrenByteArrays, match)
+        val matchByteArray = matchByteArray(match)
+        val header = generateHeader(metadata, valueByteArray, matchByteArray, childrenByteArrays,  match)
         val resultByteArray = UByteArray(arrayLength(
-                childrenByteArrays,
-                valueByteArray,
-                header
+                childArrays = childrenByteArrays,
+                valueArray = valueByteArray,
+                matchArray = matchByteArray,
+                headerArray = header
         ))
         header.copyInto(resultByteArray)
         var position = header.size
-        with(valueByteArray) {
-            copyInto(resultByteArray, position)
-            position += size
-        }
+        position = valueByteArray.copyIntoPosition(resultByteArray, position)
+        position = matchByteArray.copyIntoPosition(resultByteArray, position)
         for (childByteArray in childrenByteArrays) {
-            childByteArray.copyInto(resultByteArray, position)
-            position += childByteArray.size
+            position = childByteArray.copyIntoPosition(resultByteArray, position)
         }
         return resultByteArray
     }
 
-    private fun arrayLength(childArrays: List<UByteArray>, value: UByteArray, header: UByteArray): Int {
-        return header.size + value.size + childArrays.sumBy { it.size }
+    private fun UByteArray.copyIntoPosition(targetByteArray: UByteArray, position: Int): Int {
+        return with(targetByteArray) {
+            this@copyIntoPosition.copyInto(this, position)
+            position + this@copyIntoPosition.size
+        }
+    }
+
+    private fun arrayLength(childArrays: List<UByteArray>, valueArray: UByteArray, matchArray: UByteArray, headerArray: UByteArray): Int {
+        return headerArray.size + valueArray.size + matchArray.size + childArrays.sumBy { it.size }
     }
 
     // Make sure we match concrete matches before placeholders or configurable path segments
     private fun generateChildrenByteArrays(): List<UByteArray> = children.sortedWith(compareBy({ it.metadata.isConfigurablePathSegment }, { it.metadata.isComponentParam }, { it.id })).map { it.toUByteArray() }
 
-    private fun generateHeader(metadata: NodeMetadata, value: UByteArray, children: List<UByteArray>? = null, match: UriMatch?): UByteArray {
+    private fun generateHeader(metadata: NodeMetadata, value: UByteArray, matchByteArray: UByteArray , children: List<UByteArray>? = null, match: UriMatch?): UByteArray {
         val childrenLength: Int = children?.sumBy { it.size } ?: 0
         return UByteArray(HEADER_LENGTH).apply {
-            set(0, metadata.metadata.toUByte())
-            set(1, value.size.toUByte())
-            writeUIntAt(2, childrenLength.toUInt())
-            writeUShortAt(6, match?.matchId?.toUShort() ?: NO_MATCH.toUShort())
+            set(0, metadata.metadata.toUByte()) // flag
+            set(HEADER_NODE_METADATA_LENGTH, value.size.toUByte()) // value length
+            writeUShortAt(startIndex = HEADER_NODE_METADATA_LENGTH + HEADER_VALUE_LENGTH,
+                    value = matchByteArray.size.toUShort()) // match length
+            writeUIntAt(startIndex = HEADER_NODE_METADATA_LENGTH + HEADER_VALUE_LENGTH + HEADER_MATCH_LENGTH,
+                    value = childrenLength.toUInt()) // children length
+            writeUShortAt(startIndex = HEADER_NODE_METADATA_LENGTH + HEADER_VALUE_LENGTH + HEADER_MATCH_LENGTH + HEADER_CHILDREN_LENGTH,
+                    value = match?.matchId?.toUShort()
+                            ?: NO_MATCH.toUShort()) // match id
         }
     }
 }
@@ -102,13 +117,14 @@ data class Root(override val id: String = "r") : TreeNode(ROOT_VALUE, NodeMetada
     /**
      * Add the given DeepLinkUri to the the trie
      */
-    fun addToTrie(matchIndex: Int, deepLinkUri: DeepLinkUri, annotatedElement: String, annotatedMethod: String?) {
+    fun addToTrie(matchIndex: Int, deepLinkUriTemplate: String, annotatedClassFullyQualifiedName: String, annotatedMethod: String?) {
+        val deepLinkUri = DeepLinkUri.parse(deepLinkUriTemplate)
         var node = this.addNode(Scheme(deepLinkUri.scheme().also { validateIfComponentParam(it) }))
         if (!deepLinkUri.host().isNullOrEmpty()) {
             validateIfComponentParam(deepLinkUri.host())
             node = node.addNode(Host(deepLinkUri.host()))
             if (deepLinkUri.pathSegments().isNullOrEmpty()) {
-                node.match = UriMatch(deepLinkUri, matchIndex, annotatedElement, annotatedMethod)
+                node.match = UriMatch(deepLinkUriTemplate, matchIndex, annotatedClassFullyQualifiedName, annotatedMethod)
             }
         }
         if (!deepLinkUri.pathSegments().isNullOrEmpty()) {
@@ -117,7 +133,7 @@ data class Root(override val id: String = "r") : TreeNode(ROOT_VALUE, NodeMetada
                 validateIfConfigurablePathSegment(pathSegment)
                 node = node.addNode(PathSegment(pathSegment))
             }
-            node.match = UriMatch(deepLinkUri, matchIndex, annotatedElement, annotatedMethod)
+            node.match = UriMatch(deepLinkUriTemplate, matchIndex, annotatedClassFullyQualifiedName, annotatedMethod)
         }
     }
 }
@@ -127,6 +143,50 @@ data class Scheme(override val id: String) : TreeNode(id = id, metadata = NodeMe
 data class Host(override val id: String) : TreeNode(id = id, metadata = NodeMetadata(MetadataMasks.ComponentTypeHostMask, id))
 
 data class PathSegment(override val id: String) : TreeNode(id = id, metadata = NodeMetadata(MetadataMasks.ComponentTypePathSegmentMask, id))
+
+/**
+ * Match data byte array format is:
+ * 0..1 url                                                        url template length
+ * 2..(2+url template length)                                      url template
+ * (2+url template length)..
+ * (2+url template length)+2                                       classname length
+ * (2+url template length)+2..
+ * (2+url template length)+2+classname length                      class name
+ * (2+url template length)+2+classname length..
+ * (2+url template length)+2+classname length+1                    method name length (can be 0)
+ * (2+url template length)+2+classname length+1..
+ * (2+url template length)+2+classname length+1+method name length method name
+ */
+fun matchByteArray(match: UriMatch?): UByteArray {
+    return match?.let {
+        val uriTemplateByteArray = it.uriTemplate.toString().toByteArray(UTF_8).toUByteArray()
+        val classNameByteArray = it.annotatedClassFullyQualifiedName.toByteArray(UTF_8).toUByteArray()
+        val methodNameByteArray = it.annotatedMethod?.let { it.toByteArray(UTF_8).toUByteArray() }
+                ?: UByteArray(0)
+        UByteArray(MATCH_DATA_URL_TEMPLATE_LENGTH + uriTemplateByteArray.size
+                + MATCH_DATA_CLASS_LENGTH + classNameByteArray.size
+                + MATCH_DATA_METHOD_LENGTH + methodNameByteArray.size)
+                .apply {
+                    var position = 0
+                    // Uri template
+                    writeUShortAt(startIndex = 0, value = uriTemplateByteArray.size.toUShort())
+                    position += MATCH_DATA_URL_TEMPLATE_LENGTH
+                    uriTemplateByteArray.copyInto(destination = this, destinationOffset = position)
+                    position += uriTemplateByteArray.size
+
+                    // Class name
+                    writeUShortAt(startIndex = position, value = classNameByteArray.size.toUShort())
+                    position += MATCH_DATA_CLASS_LENGTH
+                    classNameByteArray.copyInto(destination = this, destinationOffset = position)
+                    position += classNameByteArray.size
+
+                    // method
+                    this.set(position, methodNameByteArray.size.toUByte())
+                    position += MATCH_DATA_METHOD_LENGTH
+                    if (methodNameByteArray.size > 0) methodNameByteArray.copyInto(destination = this, destinationOffset = position)
+                }
+    } ?: UByteArray(0)
+}
 
 fun UByteArray.writeUIntAt(startIndex: Int, value: UInt) {
     val ubyte3: UByte = value.and(0x000000FFu).toUByte().toUByte()

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -354,7 +354,8 @@ public class MatchIndex {
    * @return The first elementStartPos that is not part of the parent element anymore.
    */
   private int getElementBoundaryPos(int elementStartPos) {
-    return getChildrenPos(elementStartPos)
+    return getMatchDataPos(elementStartPos)
+      + getMatchLength(elementStartPos)
       + getChildrenLength(elementStartPos);
   }
 

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -58,19 +58,13 @@ public class MatchIndex {
   public static final int HEADER_VALUE_LENGTH = 1;
   public static final int HEADER_MATCH_LENGTH = 2;
   public static final int HEADER_CHILDREN_LENGTH = 4;
-  public static final int HEADER_MATCH_ID_LENGTH = 2;
   public static final int MATCH_DATA_URL_TEMPLATE_LENGTH = 2;
   public static final int MATCH_DATA_CLASS_LENGTH = 2;
   public static final int MATCH_DATA_METHOD_LENGTH = 1;
 
 
   public static final int HEADER_LENGTH = HEADER_NODE_METADATA_LENGTH + HEADER_VALUE_LENGTH
-    + HEADER_MATCH_LENGTH + HEADER_CHILDREN_LENGTH + HEADER_MATCH_ID_LENGTH;
-
-  /**
-   * Marker for no match
-   */
-  public static final int NO_MATCH = 0xffff;
+    + HEADER_MATCH_LENGTH + HEADER_CHILDREN_LENGTH;
 
   @NonNull
   public static final String ROOT_VALUE = "r";
@@ -153,10 +147,12 @@ public class MatchIndex {
               pathSegmentReplacements);
           }
         } else {
-          int matchIndex = getMatchIndex(currentElementStartPosition);
-          if (matchIndex != NO_MATCH) {
-            match = getDeeplinkEntryFromArray(byteArray, getMatchLength(currentElementStartPosition), getMatchDataPos(currentElementStartPosition));
-            match.setParameters(deeplinkUri, placeholdersOutput == null ? Collections.emptyMap() : placeholdersOutput);
+          int matchLength = getMatchLength(currentElementStartPosition);
+          if (matchLength > 0) {
+            match = getDeeplinkEntryFromArray(byteArray, matchLength, getMatchDataPos(currentElementStartPosition));
+            if (match != null) {
+              match.setParameters(deeplinkUri, placeholdersOutput == null ? Collections.emptyMap() : placeholdersOutput);
+            }
           }
         }
       }
@@ -421,20 +417,6 @@ public class MatchIndex {
         + HEADER_VALUE_LENGTH
         + HEADER_MATCH_LENGTH
     );
-  }
-
-  /**
-   * @param elementStartPos Starting position of element to process
-   * @return The match index for this element. It is either the match index or MAX_SHORT if no
-   * match.
-   */
-  private int getMatchIndex(int elementStartPos) {
-    return readTwoBytesAsInt(
-      byteArray, elementStartPos
-        + HEADER_NODE_METADATA_LENGTH
-        + HEADER_VALUE_LENGTH
-        + HEADER_MATCH_LENGTH
-        + HEADER_CHILDREN_LENGTH);
   }
 
   public int length() {

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -354,10 +354,7 @@ public class MatchIndex {
    * @return The first elementStartPos that is not part of the parent element anymore.
    */
   private int getElementBoundaryPos(int elementStartPos) {
-    return elementStartPos
-      + HEADER_LENGTH
-      + getValueLength(elementStartPos)
-      + getMatchLength(elementStartPos)
+    return getChildrenPos(elementStartPos)
       + getChildrenLength(elementStartPos);
   }
 
@@ -371,9 +368,7 @@ public class MatchIndex {
     if (getChildrenLength(elementStartPos) == 0) {
       return -1;
     } else {
-      return elementStartPos
-        + HEADER_LENGTH
-        + getValueLength(elementStartPos)
+      return getMatchDataPos(elementStartPos)
         + getMatchLength(elementStartPos);
     }
   }
@@ -388,7 +383,9 @@ public class MatchIndex {
    * @return The position of the match data sub array for the given elementStartPos.
    */
   private int getMatchDataPos(int elementStartPos) {
-    return elementStartPos + HEADER_LENGTH + getValueLength(elementStartPos);
+    return elementStartPos
+      + HEADER_LENGTH
+      + getValueLength(elementStartPos);
   }
 
   /**

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -3,9 +3,12 @@ package com.airbnb.deeplinkdispatch.base;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.airbnb.deeplinkdispatch.DeepLinkEntry;
+import com.airbnb.deeplinkdispatch.DeepLinkUri;
 import com.airbnb.deeplinkdispatch.NodeMetadata;
 import com.airbnb.deeplinkdispatch.UrlElement;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -51,13 +54,18 @@ public class MatchIndex {
   /**
    * Length of header elements in bytes
    */
-  private static final int HEADER_NODE_METADATA_LENGTH = 1;
-  private static final int HEADER_VALUE_LENGTH = 1;
-  private static final int HEADER_CHILDREN_LENGTH = 4;
-  private static final int HEADER_MATCH_ID_LENGTH = 2;
+  public static final int HEADER_NODE_METADATA_LENGTH = 1;
+  public static final int HEADER_VALUE_LENGTH = 1;
+  public static final int HEADER_MATCH_LENGTH = 2;
+  public static final int HEADER_CHILDREN_LENGTH = 4;
+  public static final int HEADER_MATCH_ID_LENGTH = 2;
+  public static final int MATCH_DATA_URL_TEMPLATE_LENGTH = 2;
+  public static final int MATCH_DATA_CLASS_LENGTH = 2;
+  public static final int MATCH_DATA_METHOD_LENGTH = 1;
+
 
   public static final int HEADER_LENGTH = HEADER_NODE_METADATA_LENGTH + HEADER_VALUE_LENGTH
-    + HEADER_CHILDREN_LENGTH + HEADER_MATCH_ID_LENGTH;
+    + HEADER_MATCH_LENGTH + HEADER_CHILDREN_LENGTH + HEADER_MATCH_ID_LENGTH;
 
   /**
    * Marker for no match
@@ -81,14 +89,16 @@ public class MatchIndex {
   /**
    * Match a given {@link com.airbnb.deeplinkdispatch.DeepLinkUri} (given as a List of
    * {@link UrlElement} against this searchh index.
-   * Will return an instance of {@link Match} if a match was found or null if there wasn't.
+   * Will return an instance of {@link DeepLinkEntry} if a match was found or null if there wasn't.
    *
+   *
+   * @param deeplinkUri The uri that should be matched
    * @param elements The {@link UrlElement} list of
-   *                 the {@link com.airbnb.deeplinkdispatch.DeepLinkUri} to match against. Must be
+   *                 the {@link DeepLinkUri} to match against. Must be
    *                 in correct order (scheme -> host -> path elements)
    * @param placeholders Placeholders (that are encoded at {name} in the Url inside the index. Used
    *                     to collect the set of placeholders and their values as
-   *                     the {@link com.airbnb.deeplinkdispatch.DeepLinkUri} is recursively
+   *                     the {@link DeepLinkUri} is recursively
    *                     processed.
    * @param elementIndex The index of the element currently processed in the elements list above.
    * @param elementStartPosition The index of the start position of the current element int he
@@ -98,12 +108,12 @@ public class MatchIndex {
    *                         the last child.
    * @param pathSegmentReplacements  A map of configurable path segment replacements and their
    *                                 values.
-   * @return An instance of {@link Match} if a match was found null if it wasn't.
+   * @return An instance of {@link DeepLinkEntry} if a match was found null if it wasn't.
    */
-  public Match matchUri(@NonNull List<UrlElement> elements, @Nullable Map<String, String>
+  public DeepLinkEntry matchUri(@NonNull DeepLinkUri deeplinkUri, @NonNull List<UrlElement> elements, @Nullable Map<String, String>
     placeholders, int elementIndex, int elementStartPosition, int parentBoundryPos,
                         Map<byte[], byte[]> pathSegmentReplacements) {
-    Match match = null;
+    DeepLinkEntry match = null;
     int currentElementStartPosition = elementStartPosition;
     do {
       UrlElement urlElement = elements.get(elementIndex);
@@ -137,7 +147,7 @@ public class MatchIndex {
             // of the current element in the index.
             // If this element match was based on an empty configurable path segment we want to
             // "skip" the match and thus use the same element or the Uri for the next round.
-            match = matchUri(elements, placeholdersOutput,
+            match = matchUri(deeplinkUri, elements, placeholdersOutput,
               compareResult.isEmptyConfigurablePathSegmentMatch() ? elementIndex : elementIndex + 1,
               childrenPos, getElementBoundaryPos(currentElementStartPosition),
               pathSegmentReplacements);
@@ -145,8 +155,8 @@ public class MatchIndex {
         } else {
           int matchIndex = getMatchIndex(currentElementStartPosition);
           if (matchIndex != NO_MATCH) {
-            match = new Match(matchIndex, placeholdersOutput == null
-              ? new HashMap<String, String>(0) : placeholdersOutput);
+            match = getDeeplinkEntryFromArray(byteArray, getMatchLength(currentElementStartPosition), getMatchDataPos(currentElementStartPosition));
+            match.setParameters(deeplinkUri, placeholdersOutput == null ? Collections.emptyMap() : placeholdersOutput);
           }
         }
       }
@@ -157,6 +167,35 @@ public class MatchIndex {
         parentBoundryPos);
     } while (currentElementStartPosition != -1);
     return null;
+  }
+
+  @Nullable
+  public static DeepLinkEntry getDeeplinkEntryFromArray(byte[] byteArray, int matchLength, int matchStartPosition ) {
+    if(matchLength == 0){
+      return null;
+    }
+    int position = matchStartPosition;
+    int urlTemplateLength = readTwoBytesAsInt(byteArray, position);
+    position += MATCH_DATA_URL_TEMPLATE_LENGTH;
+    String urlTemplate = getStringFromByteArray(byteArray, position, urlTemplateLength);
+    position += urlTemplateLength;
+    int classLength = readTwoBytesAsInt(byteArray, position);
+    position += MATCH_DATA_CLASS_LENGTH;
+    String className = getStringFromByteArray(byteArray, position, classLength);
+    Class deeplinkClass = null;
+    try {
+      deeplinkClass = Class.forName(className);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("Deeplink class " + className + " not found. If you are using Proguard/R8/Dexguard please consult README.md for correct configuration.",e);
+    }
+    position += classLength;
+    int methodLength = readOneByteAsInt(byteArray, position);
+    String methodName = null;
+    if (methodLength > 0 ) {
+      position += MATCH_DATA_METHOD_LENGTH;
+      methodName = getStringFromByteArray(byteArray, position, methodLength);
+    }
+    return new DeepLinkEntry(urlTemplate, deeplinkClass, methodName);
   }
 
   /**
@@ -308,7 +347,10 @@ public class MatchIndex {
    * @return The first elementStartPos that is not part of the parent element anymore.
    */
   private int getElementBoundaryPos(int elementStartPos) {
-    return elementStartPos + HEADER_LENGTH + getValueLength(elementStartPos)
+    return elementStartPos
+      + HEADER_LENGTH
+      + getValueLength(elementStartPos)
+      + getMatchLength(elementStartPos)
       + getChildrenLength(elementStartPos);
   }
 
@@ -322,8 +364,21 @@ public class MatchIndex {
     if (getChildrenLength(elementStartPos) == 0) {
       return -1;
     } else {
-      return elementStartPos + HEADER_LENGTH + getValueLength(elementStartPos);
+      return elementStartPos + HEADER_LENGTH + getValueLength(elementStartPos) + getMatchLength(elementStartPos);
     }
+  }
+
+  /**
+   * The position of the match data section of the element starting at elementStartPos.
+   * <p>
+   * Note: The can be 0 length in which case getMatchDataPosition() and  getChildrenPos() will
+   * return the same value.
+   *
+   * @param elementStartPos Starting position of element to process.
+   * @return The position of the match data sub array for the given elementStartPos.
+   */
+  private int getMatchDataPos(int elementStartPos) {
+    return elementStartPos + HEADER_LENGTH + getValueLength(elementStartPos);
   }
 
   /**
@@ -334,8 +389,22 @@ public class MatchIndex {
    */
   private int getValueLength(int elementStartPos) {
     return readOneByteAsInt(
-      elementStartPos
+      byteArray, elementStartPos
         + HEADER_NODE_METADATA_LENGTH
+    );
+  }
+
+  /**
+   * The length of the match section of the element starting at elementStartPos.
+   *
+   * @param elementStartPos Starting position of element to process
+   * @return The length of the match section of this element.
+   */
+  private int getMatchLength(int elementStartPos) {
+    return readTwoBytesAsInt(
+      byteArray, elementStartPos
+        + HEADER_NODE_METADATA_LENGTH
+        + HEADER_VALUE_LENGTH
     );
   }
 
@@ -347,9 +416,10 @@ public class MatchIndex {
    */
   private int getChildrenLength(int elementStartPos) {
     return readFourBytesAsInt(
-      elementStartPos
+      byteArray, elementStartPos
         + HEADER_NODE_METADATA_LENGTH
         + HEADER_VALUE_LENGTH
+        + HEADER_MATCH_LENGTH
     );
   }
 
@@ -360,9 +430,10 @@ public class MatchIndex {
    */
   private int getMatchIndex(int elementStartPos) {
     return readTwoBytesAsInt(
-      elementStartPos
+      byteArray, elementStartPos
         + HEADER_NODE_METADATA_LENGTH
         + HEADER_VALUE_LENGTH
+        + HEADER_MATCH_LENGTH
         + HEADER_CHILDREN_LENGTH);
   }
 
@@ -370,20 +441,32 @@ public class MatchIndex {
     return byteArray.length;
   }
 
-  private int readOneByteAsInt(int pos) {
+  private static int readOneByteAsInt(byte[] byteArray, int pos) {
     return byteArray[pos] & 0xFF;
   }
 
-  private int readTwoBytesAsInt(int pos) {
-    return (byteArray[pos] & 0xFF) << 8
-      | (byteArray[pos + 1] & 0xFF);
+  private static int readTwoBytesAsInt(byte[] byteArray, int pos) {
+    return (readOneByteAsInt(byteArray, pos)) << 8
+      | (readOneByteAsInt(byteArray, pos + 1));
   }
 
-  private int readFourBytesAsInt(int pos) {
-    return (byteArray[pos] & 0xFF) << 24
-      | (byteArray[pos + 1] & 0xFF) << 16
-      | (byteArray[pos + 2] & 0xFF) << 8
-      | (byteArray[pos + 3] & 0xFF);
+  private static int readFourBytesAsInt(byte[] byteArray, int pos) {
+    return (readOneByteAsInt(byteArray, pos)) << 24
+      | (readOneByteAsInt(byteArray, pos + 1)) << 16
+      | (readOneByteAsInt(byteArray, pos + 2)) << 8
+      | (readOneByteAsInt(byteArray, pos + 3));
+  }
+
+  @Nullable
+  private static String getStringFromByteArray(byte[] byteArray, int start, int length) {
+    byte[] stringByteAray = new byte[length];
+    System.arraycopy(byteArray,  start, stringByteAray, 0, length);
+    try {
+      return new String(stringByteAray, "utf-8");
+    } catch (UnsupportedEncodingException e) {
+      // Cannot be reached.
+    }
+    return null;
   }
 
   /**
@@ -395,26 +478,5 @@ public class MatchIndex {
   public static @NonNull
   String getMatchIdxFileName(@NonNull String moduleName) {
     return "dld_match_" + moduleName.toLowerCase() + ".idx";
-  }
-
-  public static class Match {
-
-    private final int matchIndex;
-    private final Map<String, String> parameterMap;
-
-    public Match(int matchIndex, @NonNull Map<String, String> parameterMap) {
-      this.matchIndex = matchIndex;
-      this.parameterMap = parameterMap;
-    }
-
-    public int getMatchIndex() {
-      return matchIndex;
-    }
-
-    public @NonNull
-    Map<String, String> getParameterMap() {
-      return parameterMap;
-    }
-
   }
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -62,7 +62,6 @@ public class MatchIndex {
   public static final int MATCH_DATA_CLASS_LENGTH = 2;
   public static final int MATCH_DATA_METHOD_LENGTH = 1;
 
-
   public static final int HEADER_LENGTH = HEADER_NODE_METADATA_LENGTH + HEADER_VALUE_LENGTH
     + HEADER_MATCH_LENGTH + HEADER_CHILDREN_LENGTH;
 
@@ -104,16 +103,20 @@ public class MatchIndex {
    *                                 values.
    * @return An instance of {@link DeepLinkEntry} if a match was found null if it wasn't.
    */
-  public DeepLinkEntry matchUri(@NonNull DeepLinkUri deeplinkUri, @NonNull List<UrlElement> elements, @Nullable Map<String, String>
-    placeholders, int elementIndex, int elementStartPosition, int parentBoundryPos,
-                        Map<byte[], byte[]> pathSegmentReplacements) {
+  public DeepLinkEntry matchUri(@NonNull DeepLinkUri deeplinkUri,
+                                @NonNull List<UrlElement> elements,
+                                @Nullable Map<String, String> placeholders,
+                                int elementIndex,
+                                int elementStartPosition,
+                                int parentBoundryPos,
+                                Map<byte[], byte[]> pathSegmentReplacements) {
     DeepLinkEntry match = null;
     int currentElementStartPosition = elementStartPosition;
     do {
       UrlElement urlElement = elements.get(elementIndex);
       CompareResult compareResult =
         compareValue(currentElementStartPosition, urlElement.getTypeFlag(),
-        urlElement.getValue(), pathSegmentReplacements);
+          urlElement.getValue(), pathSegmentReplacements);
       if (compareResult != null) {
         Map<String, String> placeholdersOutput = placeholders;
         // If the compareResult is not empty we found a match with a placeholder. We need to save
@@ -149,9 +152,12 @@ public class MatchIndex {
         } else {
           int matchLength = getMatchLength(currentElementStartPosition);
           if (matchLength > 0) {
-            match = getDeeplinkEntryFromArray(byteArray, matchLength, getMatchDataPos(currentElementStartPosition));
+            match = getDeeplinkEntryFromArray(byteArray,
+              matchLength,
+              getMatchDataPos(currentElementStartPosition));
             if (match != null) {
-              match.setParameters(deeplinkUri, placeholdersOutput == null ? Collections.emptyMap() : placeholdersOutput);
+              match.setParameters(deeplinkUri,
+                placeholdersOutput == null ? Collections.emptyMap() : placeholdersOutput);
             }
           }
         }
@@ -166,8 +172,10 @@ public class MatchIndex {
   }
 
   @Nullable
-  public static DeepLinkEntry getDeeplinkEntryFromArray(byte[] byteArray, int matchLength, int matchStartPosition ) {
-    if(matchLength == 0){
+  public static DeepLinkEntry getDeeplinkEntryFromArray(byte[] byteArray,
+                                                        int matchLength,
+                                                        int matchStartPosition) {
+    if (matchLength == 0) {
       return null;
     }
     int position = matchStartPosition;
@@ -182,12 +190,15 @@ public class MatchIndex {
     try {
       deeplinkClass = Class.forName(className);
     } catch (ClassNotFoundException e) {
-      throw new IllegalStateException("Deeplink class " + className + " not found. If you are using Proguard/R8/Dexguard please consult README.md for correct configuration.",e);
+      throw new IllegalStateException(
+        "Deeplink class " + className + " not found. If you are using Proguard/R8/Dexguard please "
+          + "consult README.md for correct configuration.", e
+      );
     }
     position += classLength;
     int methodLength = readOneByteAsInt(byteArray, position);
     String methodName = null;
-    if (methodLength > 0 ) {
+    if (methodLength > 0) {
       position += MATCH_DATA_METHOD_LENGTH;
       methodName = getStringFromByteArray(byteArray, position, methodLength);
     }
@@ -360,7 +371,10 @@ public class MatchIndex {
     if (getChildrenLength(elementStartPos) == 0) {
       return -1;
     } else {
-      return elementStartPos + HEADER_LENGTH + getValueLength(elementStartPos) + getMatchLength(elementStartPos);
+      return elementStartPos
+        + HEADER_LENGTH
+        + getValueLength(elementStartPos)
+        + getMatchLength(elementStartPos);
     }
   }
 

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTests.kt
@@ -5,11 +5,11 @@ import org.junit.Test
 
 class DeepLinkEntryTests {
 
-    private val concrete = DeepLinkEntry("scheme://host/one/two/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
-    private val parmSecondPathElement = DeepLinkEntry("scheme://host/one/{param}/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
-    private val parmFirstPathElement = DeepLinkEntry("scheme://host/{param}/two/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
-    private val cpsSecondPathSegment = DeepLinkEntry("scheme://host/one/<config>/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
-    private val cpsFirstPathSegment = DeepLinkEntry("scheme://host/<config>/two/three", DeepLinkEntry.Type.CLASS, this.javaClass, null)
+    private val concrete = DeepLinkEntry("scheme://host/one/two/three", this.javaClass, null)
+    private val parmSecondPathElement = DeepLinkEntry("scheme://host/one/{param}/three", this.javaClass, null)
+    private val parmFirstPathElement = DeepLinkEntry("scheme://host/{param}/two/three", this.javaClass, null)
+    private val cpsSecondPathSegment = DeepLinkEntry("scheme://host/one/<config>/three", this.javaClass, null)
+    private val cpsFirstPathSegment = DeepLinkEntry("scheme://host/<config>/two/three", this.javaClass, null)
 
     @Test fun testSameness(){
         assertTrue(concrete.compareTo(concrete) == 0)

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
@@ -1,0 +1,47 @@
+package com.airbnb.deeplinkdispatch
+
+import com.airbnb.deeplinkdispatch.base.MatchIndex
+import org.junit.Assert.*
+import org.junit.Test
+import java.lang.IllegalStateException
+
+private const val ONE_PARAM_SCHEMA = "scheme://host/one/{param}/three"
+private const val METHOD_NAME = "methodName"
+
+class DeepLinkMatchTests {
+
+    @Test
+    fun testMatchArraySerializationDeserializationNoMethod() {
+        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, 1234, this.javaClass.name, null))
+        val entryFromArray = MatchIndex.getDeeplinkEntryFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0)
+        assertNotNull(entryFromArray)
+        entryFromArray?.let {
+            assertEquals(ONE_PARAM_SCHEMA.toString(), it.uriTemplate)
+            assertEquals(this.javaClass, it.activityClass)
+            assertNull(it.method)
+        }
+    }
+
+    @Test
+    fun testMatchArraySerializationDeserialization() {
+        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, 1234, this.javaClass.name, METHOD_NAME))
+        val entryFromArray = MatchIndex.getDeeplinkEntryFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0)
+        assertNotNull(entryFromArray)
+        entryFromArray?.let {
+            assertEquals(ONE_PARAM_SCHEMA, it.uriTemplate)
+            assertEquals(this.javaClass, it.activityClass)
+            assertEquals(METHOD_NAME, it.method)
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun testMatchArraySerializationDeserializationNonExistantClass() {
+        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, 1234, "soneNonexistantClass", null))
+        val entryFromArray = MatchIndex.getDeeplinkEntryFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0)
+    }
+
+    @Test fun testMatchArraySerializationDeserializationNoMatch(){
+        val entryFromArray = MatchIndex.getDeeplinkEntryFromArray(ByteArray(0), 0, 0)
+        assertNull(entryFromArray)
+    }
+}

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
@@ -12,7 +12,7 @@ class DeepLinkMatchTests {
 
     @Test
     fun testMatchArraySerializationDeserializationNoMethod() {
-        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, 1234, this.javaClass.name, null))
+        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, this.javaClass.name, null))
         val entryFromArray = MatchIndex.getDeeplinkEntryFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0)
         assertNotNull(entryFromArray)
         entryFromArray?.let {
@@ -24,7 +24,7 @@ class DeepLinkMatchTests {
 
     @Test
     fun testMatchArraySerializationDeserialization() {
-        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, 1234, this.javaClass.name, METHOD_NAME))
+        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, this.javaClass.name, METHOD_NAME))
         val entryFromArray = MatchIndex.getDeeplinkEntryFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0)
         assertNotNull(entryFromArray)
         entryFromArray?.let {
@@ -36,7 +36,7 @@ class DeepLinkMatchTests {
 
     @Test(expected = IllegalStateException::class)
     fun testMatchArraySerializationDeserializationNonExistantClass() {
-        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, 1234, "soneNonexistantClass", null))
+        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, "soneNonexistantClass", null))
         val entryFromArray = MatchIndex.getDeeplinkEntryFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0)
     }
 

--- a/deeplinkdispatch-processor/build.gradle
+++ b/deeplinkdispatch-processor/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   testImplementation deps.compileTesting
   testImplementation deps.truth
   testImplementation deps.mockito
-  testImplementation files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
+  testImplementation files("${System.properties['java.home']}/../lib/tools.jar")
 }
 
 checkstyle {

--- a/deeplinkdispatch-processor/build.gradle
+++ b/deeplinkdispatch-processor/build.gradle
@@ -6,14 +6,6 @@ sourceCompatibility = 1.8
 apply plugin: 'checkstyle'
 apply plugin: 'com.vanniktech.maven.publish'
 
-sourceSets {
-  test {
-    java {
-      srcDir '../deeplinkdispatch/src/main/java' // In tests we need access to the runtime files from the dld library
-    }
-  }
-}
-
 dependencies {
   implementation project(':deeplinkdispatch-base')
   implementation deps.jsr305

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -354,15 +354,14 @@ public class DeepLinkProcessor extends AbstractProcessor {
       ClassName activity = ClassName.get(element.getAnnotatedElement());
       Object method = element.getMethod();
       String uri = element.getUri();
-      DeepLinkUri deeplinkUri = DeepLinkUri.parse(uri);
 
       try {
-        urisTrie.addToTrie(i, deeplinkUri, element.getAnnotatedElement().toString(),
-          element.getMethod());
+        urisTrie.addToTrie(i, uri, activity.canonicalName(), element.getMethod());
       } catch (IllegalArgumentException e) {
         error(element.getAnnotatedElement(), e.getMessage());
       }
 
+      DeepLinkUri deeplinkUri = DeepLinkUri.parse(uri);
       //Keep track of pathVariables added in a module so that we can check at runtime to ensure
       //that all pathVariables have a corresponding entry provided to BaseDeepLinkDelegate.
       for (String pathSegment : deeplinkUri.pathSegments()) {
@@ -371,8 +370,8 @@ public class DeepLinkProcessor extends AbstractProcessor {
             pathSegment.length() - configurablePathSegmentSuffix.length()));
         }
       }
-      deeplinks.add("new DeepLinkEntry($S, $L, $T.class, $S)$L\n",
-        uri, type, activity, method, (i < totalElements - 1) ? "," : "");
+      deeplinks.add("new DeepLinkEntry($S, $T.class, $S)$L\n",
+        uri, activity, method, (i < totalElements - 1) ? "," : "");
     }
 
     TypeSpec.Builder deepLinkRegistryBuilder = TypeSpec.classBuilder(className

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkProcessorTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkProcessorTest.java
@@ -1,0 +1,25 @@
+package com.airbnb.deeplinkdispatch;
+
+import com.google.testing.compile.JavaFileObjects;
+
+import javax.tools.JavaFileObject;
+
+class BaseDeepLinkProcessorTest {
+
+  protected final JavaFileObject fakeBaseDeeplinkDelegate = JavaFileObjects
+    .forSourceString("BaseDeepLinkDelegate", "package com.airbnb.deeplinkdispatch;\n" +
+      "\n" +
+      "import java.util.List;\n" +
+      "import java.util.Map;\n" +
+      "\n" +
+      "public class BaseDeepLinkDelegate {" +
+      "  public BaseDeepLinkDelegate(List<? extends BaseRegistry> registries) {\n" +
+      "  }" +
+      "\n" +
+      "  public BaseDeepLinkDelegate(\n" +
+      "    List<? extends BaseRegistry> registries,\n" +
+      "    Map<String, String> configurablePathSegmentReplacements\n" +
+      "  ) {}\n" +
+      "}");
+
+}

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkProcessorTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkProcessorTest.java
@@ -7,19 +7,19 @@ import javax.tools.JavaFileObject;
 class BaseDeepLinkProcessorTest {
 
   protected final JavaFileObject fakeBaseDeeplinkDelegate = JavaFileObjects
-    .forSourceString("BaseDeepLinkDelegate", "package com.airbnb.deeplinkdispatch;\n" +
-      "\n" +
-      "import java.util.List;\n" +
-      "import java.util.Map;\n" +
-      "\n" +
-      "public class BaseDeepLinkDelegate {" +
-      "  public BaseDeepLinkDelegate(List<? extends BaseRegistry> registries) {\n" +
-      "  }" +
-      "\n" +
-      "  public BaseDeepLinkDelegate(\n" +
-      "    List<? extends BaseRegistry> registries,\n" +
-      "    Map<String, String> configurablePathSegmentReplacements\n" +
-      "  ) {}\n" +
-      "}");
+    .forSourceString("BaseDeepLinkDelegate", "package com.airbnb.deeplinkdispatch;\n"
+      + "\n"
+      + "import java.util.List;\n"
+      + "import java.util.Map;\n"
+      + "\n"
+      + "public class BaseDeepLinkDelegate {"
+      + "  public BaseDeepLinkDelegate(List<? extends BaseRegistry> registries) {\n"
+      + "  }"
+      + "\n"
+      + "  public BaseDeepLinkDelegate(\n"
+      + "    List<? extends BaseRegistry> registries,\n"
+      + "    Map<String, String> configurablePathSegmentReplacements\n"
+      + "  ) {}\n"
+      + "}");
 
 }

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.java
@@ -11,7 +11,7 @@ import javax.tools.JavaFileObject;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
-public class DeepLinkProcessorIncrementalTest {
+public class DeepLinkProcessorIncrementalTest extends BaseDeepLinkProcessorTest {
   private final JavaFileObject customAnnotationAppLink = JavaFileObjects
     .forSourceString("AppDeepLink", "package com.example;\n"
       + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
@@ -48,7 +48,7 @@ public class DeepLinkProcessorIncrementalTest {
   @Test
   public void testIncrementalProcessorWithCustomDeepLinkRegistration() {
     assertAbout(javaSources())
-      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
+      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink, fakeBaseDeeplinkDelegate))
       .withCompilerOptions("-AdeepLink.incremental=true")
       .withCompilerOptions("-AdeepLink.customAnnotations=com.example.AppDeepLink")
       .processedWith(new DeepLinkProcessor())
@@ -84,7 +84,7 @@ public class DeepLinkProcessorIncrementalTest {
   @Test
   public void testIncrementalProcessorWithoutCustomDeepLinkRegistration() {
     assertAbout(javaSources())
-      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
+      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink, fakeBaseDeeplinkDelegate))
       .withCompilerOptions("-AdeepLink.incremental=true")
       .processedWith(new DeepLinkProcessor())
       .compilesWithoutError()

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.java
@@ -48,7 +48,10 @@ public class DeepLinkProcessorIncrementalTest extends BaseDeepLinkProcessorTest 
   @Test
   public void testIncrementalProcessorWithCustomDeepLinkRegistration() {
     assertAbout(javaSources())
-      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink, fakeBaseDeeplinkDelegate))
+      .that(Arrays.asList(customAnnotationAppLink,
+        module,
+        sampleActivityWithOnlyCustomDeepLink,
+        fakeBaseDeeplinkDelegate))
       .withCompilerOptions("-AdeepLink.incremental=true")
       .withCompilerOptions("-AdeepLink.customAnnotations=com.example.AppDeepLink")
       .processedWith(new DeepLinkProcessor())
@@ -84,7 +87,10 @@ public class DeepLinkProcessorIncrementalTest extends BaseDeepLinkProcessorTest 
   @Test
   public void testIncrementalProcessorWithoutCustomDeepLinkRegistration() {
     assertAbout(javaSources())
-      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink, fakeBaseDeeplinkDelegate))
+      .that(Arrays.asList(customAnnotationAppLink,
+        module,
+        sampleActivityWithOnlyCustomDeepLink,
+        fakeBaseDeeplinkDelegate))
       .withCompilerOptions("-AdeepLink.incremental=true")
       .processedWith(new DeepLinkProcessor())
       .compilesWithoutError()

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.java
@@ -45,75 +45,71 @@ public class DeepLinkProcessorIncrementalTest {
       + "public class SampleModule {\n"
       + "}");
 
-//  @Test
-//  public void testIncrementalProcessorWithCustomDeepLinkRegistration() {
-//    assertAbout(javaSources())
-//      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
-//      .withCompilerOptions("-AdeepLink.incremental=true")
-//      .withCompilerOptions("-AdeepLink.customAnnotations=com.example.AppDeepLink")
-//      .processedWith(new DeepLinkProcessor())
-//      .compilesWithoutError()
-//      .and()
-//      .generatesSources(
-//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example"
-//            + ".SampleModuleRegistry",
-//          "package com.example;\n"
-//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-//            + "import java.lang.String;\n"
-//            + "import java.util.Arrays;\n"
-//            + "import java.util.Collections;\n"
-//            + "\n"
-//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-//            + "  public SampleModuleRegistry() {\n"
-//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-//            + "      new DeepLinkEntry(\"example://example.com/deepLink\""
-//            + ", SampleActivity.class, null)\n"
-//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-//            + "    new String[]{});\n"
-//            + "  }\n"
-//            + "\n"
-//            + "  private static String matchIndex0() {\n"
-//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00002ÿÿr\\u0002\\u0007\\u0000\\u0000\\u0"
-//            + "000#ÿÿexample\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u"
-//            + "0000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
-//            + "}"
-//        ));
-//  }
+  @Test
+  public void testIncrementalProcessorWithCustomDeepLinkRegistration() {
+    assertAbout(javaSources())
+      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
+      .withCompilerOptions("-AdeepLink.incremental=true")
+      .withCompilerOptions("-AdeepLink.customAnnotations=com.example.AppDeepLink")
+      .processedWith(new DeepLinkProcessor())
+      .compilesWithoutError()
+      .and()
+      .generatesSources(
+        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example"
+            + ".SampleModuleRegistry",
+          "package com.example;\n"
+            + "\n"
+            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+            + "  public SampleModuleRegistry() {\n"
+            + "    super(Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+            + "    new String[]{});\n"
+            + "  }\n"
+            + "\n"
+            + "  private static String matchIndex0() {\n"
+            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000\\u0000or\\u0002\\u0007"
+            + "\\u0000\\u0000\\u0000\\u0000\\u0000`example\\u0004\\u000b\\u0000\\u0000\\u0000"
+            + "\\u0000\\u0000Mexample.com\\b\\b\\u0000=\\u0000\\u0000\\u0000\\u0000deepLink\\u0000"
+            + "\\u001eexample://example.com/deepLink"
+            + "\\u0000\\u001acom.example.SampleActivity\\u0000\";\n"
+            + "  }\n"
+            + "}"
+        ));
+  }
 
-//  @Test
-//  public void testIncrementalProcessorWithoutCustomDeepLinkRegistration() {
-//    assertAbout(javaSources())
-//      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
-//      .withCompilerOptions("-AdeepLink.incremental=true")
-//      .processedWith(new DeepLinkProcessor())
-//      .compilesWithoutError()
-//      .and()
-//      .generatesSources(
-//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example"
-//            + ".SampleModuleRegistry",
-//          "package com.example;"
-//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-//            + "import java.lang.String;\n"
-//            + "import java.util.Arrays;\n"
-//            + "import java.util.Collections;\n"
-//            + "\n"
-//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-//            + "  public SampleModuleRegistry() {\n"
-//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-//            + "    new String[]{});\n"
-//            + "  }\n"
-//            + "\n"
-//            + "  private static String matchIndex0() {\n"
-//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000ÿÿr\";}\n"
-//            + "}\n"));
-//  }
+  @Test
+  public void testIncrementalProcessorWithoutCustomDeepLinkRegistration() {
+    assertAbout(javaSources())
+      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
+      .withCompilerOptions("-AdeepLink.incremental=true")
+      .processedWith(new DeepLinkProcessor())
+      .compilesWithoutError()
+      .and()
+      .generatesSources(
+        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example"
+            + ".SampleModuleRegistry",
+          "package com.example;\n"
+            + "\n"
+            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+            + "  public SampleModuleRegistry() {\n"
+            + "    super(Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+            + "    new String[]{});\n"
+            + "  }\n"
+            + "\n"
+            + "  private static String matchIndex0() {\n"
+            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000\\u0000\\u0000r\";\n"
+            + "  }\n"
+            + "}"));
+  }
 
   @Test
   public void testCustomAnnotationMissingFromCompilerOptionsErrorMessage() {

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.java
@@ -45,75 +45,75 @@ public class DeepLinkProcessorIncrementalTest {
       + "public class SampleModule {\n"
       + "}");
 
-  @Test
-  public void testIncrementalProcessorWithCustomDeepLinkRegistration() {
-    assertAbout(javaSources())
-      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
-      .withCompilerOptions("-AdeepLink.incremental=true")
-      .withCompilerOptions("-AdeepLink.customAnnotations=com.example.AppDeepLink")
-      .processedWith(new DeepLinkProcessor())
-      .compilesWithoutError()
-      .and()
-      .generatesSources(
-        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example"
-            + ".SampleModuleRegistry",
-          "package com.example;\n"
-            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-            + "import java.lang.String;\n"
-            + "import java.util.Arrays;\n"
-            + "import java.util.Collections;\n"
-            + "\n"
-            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-            + "  public SampleModuleRegistry() {\n"
-            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-            + "      new DeepLinkEntry(\"example://example.com/deepLink\", DeepLinkEntry.Type.CLASS"
-            + ", SampleActivity.class, null)\n"
-            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-            + "    new String[]{});\n"
-            + "  }\n"
-            + "\n"
-            + "  private static String matchIndex0() {\n"
-            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00002ÿÿr\\u0002\\u0007\\u0000\\u0000\\u0"
-            + "000#ÿÿexample\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u"
-            + "0000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
-            + "}"
-        ));
-  }
+//  @Test
+//  public void testIncrementalProcessorWithCustomDeepLinkRegistration() {
+//    assertAbout(javaSources())
+//      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
+//      .withCompilerOptions("-AdeepLink.incremental=true")
+//      .withCompilerOptions("-AdeepLink.customAnnotations=com.example.AppDeepLink")
+//      .processedWith(new DeepLinkProcessor())
+//      .compilesWithoutError()
+//      .and()
+//      .generatesSources(
+//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example"
+//            + ".SampleModuleRegistry",
+//          "package com.example;\n"
+//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
+//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+//            + "import java.lang.String;\n"
+//            + "import java.util.Arrays;\n"
+//            + "import java.util.Collections;\n"
+//            + "\n"
+//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+//            + "  public SampleModuleRegistry() {\n"
+//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
+//            + "      new DeepLinkEntry(\"example://example.com/deepLink\""
+//            + ", SampleActivity.class, null)\n"
+//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+//            + "    new String[]{});\n"
+//            + "  }\n"
+//            + "\n"
+//            + "  private static String matchIndex0() {\n"
+//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00002ÿÿr\\u0002\\u0007\\u0000\\u0000\\u0"
+//            + "000#ÿÿexample\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u"
+//            + "0000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
+//            + "}"
+//        ));
+//  }
 
-  @Test
-  public void testIncrementalProcessorWithoutCustomDeepLinkRegistration() {
-    assertAbout(javaSources())
-      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
-      .withCompilerOptions("-AdeepLink.incremental=true")
-      .processedWith(new DeepLinkProcessor())
-      .compilesWithoutError()
-      .and()
-      .generatesSources(
-        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example"
-            + ".SampleModuleRegistry",
-          "package com.example;"
-            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-            + "import java.lang.String;\n"
-            + "import java.util.Arrays;\n"
-            + "import java.util.Collections;\n"
-            + "\n"
-            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-            + "  public SampleModuleRegistry() {\n"
-            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-            + "    new String[]{});\n"
-            + "  }\n"
-            + "\n"
-            + "  private static String matchIndex0() {\n"
-            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000ÿÿr\";}\n"
-            + "}\n"));
-  }
+//  @Test
+//  public void testIncrementalProcessorWithoutCustomDeepLinkRegistration() {
+//    assertAbout(javaSources())
+//      .that(Arrays.asList(customAnnotationAppLink, module, sampleActivityWithOnlyCustomDeepLink))
+//      .withCompilerOptions("-AdeepLink.incremental=true")
+//      .processedWith(new DeepLinkProcessor())
+//      .compilesWithoutError()
+//      .and()
+//      .generatesSources(
+//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example"
+//            + ".SampleModuleRegistry",
+//          "package com.example;"
+//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
+//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+//            + "import java.lang.String;\n"
+//            + "import java.util.Arrays;\n"
+//            + "import java.util.Collections;\n"
+//            + "\n"
+//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+//            + "  public SampleModuleRegistry() {\n"
+//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
+//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+//            + "    new String[]{});\n"
+//            + "  }\n"
+//            + "\n"
+//            + "  private static String matchIndex0() {\n"
+//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000ÿÿr\";}\n"
+//            + "}\n"));
+//  }
 
   @Test
   public void testCustomAnnotationMissingFromCompilerOptionsErrorMessage() {

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
@@ -37,135 +37,135 @@ public class DeepLinkProcessorNonIncrementalTest {
         + "public class SampleModule {\n"
         + "}");
 
-  @Test
-  public void testProcessor() {
-    JavaFileObject sampleActivity = JavaFileObjects
-      .forSourceString("SampleActivity", "package com.example;"
-        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
-        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
-        + "import com.example.SampleModule;\n\n"
-        + "@DeepLink(\"airbnb://example.com/deepLink\")\n"
-        + "@DeepLinkHandler({ SampleModule.class })\n"
-        + "public class SampleActivity {\n"
-        + "}");
+//  @Test
+//  public void testProcessor() {
+//    JavaFileObject sampleActivity = JavaFileObjects
+//      .forSourceString("SampleActivity", "package com.example;"
+//        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+//        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
+//        + "import com.example.SampleModule;\n\n"
+//        + "@DeepLink(\"airbnb://example.com/deepLink\")\n"
+//        + "@DeepLinkHandler({ SampleModule.class })\n"
+//        + "public class SampleActivity {\n"
+//        + "}");
+//
+//    assertAbout(javaSources())
+//      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
+//      .processedWith(new DeepLinkProcessor())
+//      .compilesWithoutError()
+//      .and()
+//      .generatesSources(
+//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleRe"
+//            + "gistry",
+//          "package com.example;\n"
+//            + "\n"
+//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
+//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+//            + "import java.lang.String;\n"
+//            + "import java.util.Arrays;\n"
+//            + "import java.util.Collections;\n"
+//            + "\n"
+//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+//            + "  public SampleModuleRegistry() {\n"
+//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
+//            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", SampleActivity.class,"
+//            + " null)\n"
+//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+//            + "    new String[]{});\n"
+//            + "  }\n"
+//            + "\n"
+//            + "  private static String matchIndex0() {\n"
+//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00001ÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
+//            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
+//            + "000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
+//            + "}"
+//        ));
+//  }
 
-    assertAbout(javaSources())
-      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
-      .processedWith(new DeepLinkProcessor())
-      .compilesWithoutError()
-      .and()
-      .generatesSources(
-        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleRe"
-            + "gistry",
-          "package com.example;\n"
-            + "\n"
-            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-            + "import java.lang.String;\n"
-            + "import java.util.Arrays;\n"
-            + "import java.util.Collections;\n"
-            + "\n"
-            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-            + "  public SampleModuleRegistry() {\n"
-            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", DeepLinkEntry.Type.CLASS,"
-            + "SampleActivity.class, null)\n"
-            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-            + "    new String[]{});\n"
-            + "  }\n"
-            + "\n"
-            + "  private static String matchIndex0() {\n"
-            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00001ÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
-            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
-            + "000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
-            + "}"
-        ));
-  }
-
-  @Test
-  public void testProcessorWithDefaultAndCustomAnnotations() {
-    JavaFileObject customAnnotationWebLink = JavaFileObjects
-      .forSourceString("WebDeepLink", "package com.example;\n"
-        + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
-        + "@DeepLinkSpec(prefix = { \"http://\", \"https://\"})\n"
-        + "public @interface WebDeepLink {\n"
-        + "    String[] value();\n"
-        + "}");
-    JavaFileObject customAnnotationAppLink = JavaFileObjects
-      .forSourceString("AppDeepLink", "package com.example;\n"
-        + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
-        + "@DeepLinkSpec(prefix = { \"example://\" })\n"
-        + "public @interface AppDeepLink {\n"
-        + "    String[] value();\n"
-        + "}");
-    JavaFileObject sampleActivity = JavaFileObjects
-      .forSourceString("SampleActivity", "package com.example;"
-        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
-        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
-        + "import com.example.SampleModule;\n\n"
-        + "@DeepLink(\"airbnb://example.com/deepLink\")\n"
-        + "@AppDeepLink({\"example.com/deepLink\",\"example.com/another\"})\n"
-        + "@WebDeepLink({\"example.com/deepLink\",\"example.com/another\"})\n"
-        + "@DeepLinkHandler({ SampleModule.class })\n"
-        + "public class SampleActivity {\n"
-        + "}");
-
-    assertAbout(javaSources())
-      .that(Arrays.asList(customAnnotationAppLink, customAnnotationWebLink,
-        SIMPLE_DEEPLINK_MODULE, sampleActivity))
-      .processedWith(new DeepLinkProcessor())
-      .compilesWithoutError()
-      .and()
-      .generatesSources(
-        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleRegistry",
-          "package com.example;\n"
-            + "\n"
-            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-            + "import java.lang.String;\n"
-            + "import java.util.Arrays;\n"
-            + "import java.util.Collections;\n"
-            + "\n"
-            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-            + "  public SampleModuleRegistry() {\n"
-            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", DeepLinkEntry.Type.CLASS,"
-            + "SampleActivity.class, null),\n"
-            + "      new DeepLinkEntry(\"example://example.com/another\", DeepLinkEntry.Type.CLASS,"
-            + "SampleActivity.class, null),\n"
-            + "      new DeepLinkEntry(\"example://example.com/deepLink\", DeepLinkEntry.Type.CLASS"
-            + ", SampleActivity.class, null),\n"
-            + "      new DeepLinkEntry(\"http://example.com/another\", DeepLinkEntry.Type.CLASS, Sa"
-            + "mpleActivity.class, null),\n"
-            + "      new DeepLinkEntry(\"http://example.com/deepLink\", DeepLinkEntry.Type.CLASS, S"
-            + "ampleActivity.class, null),\n"
-            + "      new DeepLinkEntry(\"https://example.com/another\", DeepLinkEntry.Type.CLASS, S"
-            + "ampleActivity.class, null),\n"
-            + "      new DeepLinkEntry(\"https://example.com/deepLink\", DeepLinkEntry.Type.CLASS, "
-            + "SampleActivity.class, null)\n"
-            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-            + "    new String[]{});\n"
-            + "  }\n"
-            + "\n"
-            + "  private static String matchIndex0() {\n"
-            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000ïÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
-            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
-            + "000\\u0000\\u0000\\u0000\\u0000deepLink\\u0002\\u0007\\u0000\\u0000\\u00002ÿÿexample"
-            + "\\u0004\\u000b\\u0000\\u0000\\u0000\\u001fÿÿexample.com\\b\\u0007\\u0000\\u0000\\u00"
-            + "00\\u0000\\u0000\\u0001another\\b\\b\\u0000\\u0000\\u0000\\u0000\\u0000\\u0002deepLi"
-            + "nk\\u0002\\u0004\\u0000\\u0000\\u00002ÿÿhttp\\u0004\\u000b\\u0000\\u0000\\u0000\\u00"
-            + "1fÿÿexample.com\\b\\u0007\\u0000\\u0000\\u0000\\u0000\\u0000\\u0003another\\b\\b\\u0"
-            + "000\\u0000\\u0000\\u0000\\u0000\\u0004deepLink\\u0002\\u0005\\u0000\\u0000\\u00002ÿÿ"
-            + "https\\u0004\\u000b\\u0000\\u0000\\u0000\\u001fÿÿexample.com\\b\\u0007\\u0000\\u0000"
-            + "\\u0000\\u0000\\u0000\\u0005another\\b\\b\\u0000\\u0000\\u0000\\u0000\\u0000\\u0006d"
-            + "eepLink\";}\n"
-            + "}"
-        ));
-  }
+//  @Test
+//  public void testProcessorWithDefaultAndCustomAnnotations() {
+//    JavaFileObject customAnnotationWebLink = JavaFileObjects
+//      .forSourceString("WebDeepLink", "package com.example;\n"
+//        + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
+//        + "@DeepLinkSpec(prefix = { \"http://\", \"https://\"})\n"
+//        + "public @interface WebDeepLink {\n"
+//        + "    String[] value();\n"
+//        + "}");
+//    JavaFileObject customAnnotationAppLink = JavaFileObjects
+//      .forSourceString("AppDeepLink", "package com.example;\n"
+//        + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
+//        + "@DeepLinkSpec(prefix = { \"example://\" })\n"
+//        + "public @interface AppDeepLink {\n"
+//        + "    String[] value();\n"
+//        + "}");
+//    JavaFileObject sampleActivity = JavaFileObjects
+//      .forSourceString("SampleActivity", "package com.example;"
+//        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+//        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
+//        + "import com.example.SampleModule;\n\n"
+//        + "@DeepLink(\"airbnb://example.com/deepLink\")\n"
+//        + "@AppDeepLink({\"example.com/deepLink\",\"example.com/another\"})\n"
+//        + "@WebDeepLink({\"example.com/deepLink\",\"example.com/another\"})\n"
+//        + "@DeepLinkHandler({ SampleModule.class })\n"
+//        + "public class SampleActivity {\n"
+//        + "}");
+//
+//    assertAbout(javaSources())
+//      .that(Arrays.asList(customAnnotationAppLink, customAnnotationWebLink,
+//        SIMPLE_DEEPLINK_MODULE, sampleActivity))
+//      .processedWith(new DeepLinkProcessor())
+//      .compilesWithoutError()
+//      .and()
+//      .generatesSources(
+//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleRegistry",
+//          "package com.example;\n"
+//            + "\n"
+//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
+//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+//            + "import java.lang.String;\n"
+//            + "import java.util.Arrays;\n"
+//            + "import java.util.Collections;\n"
+//            + "\n"
+//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+//            + "  public SampleModuleRegistry() {\n"
+//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
+//            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", "
+//            + "SampleActivity.class, null),\n"
+//            + "      new DeepLinkEntry(\"example://example.com/another\", "
+//            + "SampleActivity.class, null),\n"
+//            + "      new DeepLinkEntry(\"example://example.com/deepLink\", "
+//            + "SampleActivity.class, null),\n"
+//            + "      new DeepLinkEntry(\"http://example.com/another\", "
+//            + "SampleActivity.class, null),\n"
+//            + "      new DeepLinkEntry(\"http://example.com/deepLink\", "
+//            + "SampleActivity.class, null),\n"
+//            + "      new DeepLinkEntry(\"https://example.com/another\", "
+//            + "SampleActivity.class, null),\n"
+//            + "      new DeepLinkEntry(\"https://example.com/deepLink\", "
+//            + "SampleActivity.class, null)\n"
+//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+//            + "    new String[]{});\n"
+//            + "  }\n"
+//            + "\n"
+//            + "  private static String matchIndex0() {\n"
+//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000ïÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
+//            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
+//            + "000\\u0000\\u0000\\u0000\\u0000deepLink\\u0002\\u0007\\u0000\\u0000\\u00002ÿÿexample"
+//            + "\\u0004\\u000b\\u0000\\u0000\\u0000\\u001fÿÿexample.com\\b\\u0007\\u0000\\u0000\\u00"
+//            + "00\\u0000\\u0000\\u0001another\\b\\b\\u0000\\u0000\\u0000\\u0000\\u0000\\u0002deepLi"
+//            + "nk\\u0002\\u0004\\u0000\\u0000\\u00002ÿÿhttp\\u0004\\u000b\\u0000\\u0000\\u0000\\u00"
+//            + "1fÿÿexample.com\\b\\u0007\\u0000\\u0000\\u0000\\u0000\\u0000\\u0003another\\b\\b\\u0"
+//            + "000\\u0000\\u0000\\u0000\\u0000\\u0004deepLink\\u0002\\u0005\\u0000\\u0000\\u00002ÿÿ"
+//            + "https\\u0004\\u000b\\u0000\\u0000\\u0000\\u001fÿÿexample.com\\b\\u0007\\u0000\\u0000"
+//            + "\\u0000\\u0000\\u0000\\u0005another\\b\\b\\u0000\\u0000\\u0000\\u0000\\u0000\\u0006d"
+//            + "eepLink\";}\n"
+//            + "}"
+//        ));
+//  }
 
   @Test
   public void testDuplicatedUriMatch() {
@@ -213,58 +213,60 @@ public class DeepLinkProcessorNonIncrementalTest {
       .processedWith(new DeepLinkProcessor())
       .failsToCompile().withErrorContaining("Internal error during annotation "
       + "processing: java.lang.IllegalStateException: Ambiguous URI. Same match for two URIs "
-      + "(UriMatch(uri=airbnb://host/path1/path2?q={q}, matchId=0, annotatedElement=com.example."
-      + "SampleActivity, annotatedMethod=intentFromTwoPathWithQuery) vs UriMatch(uri="
-      + "airbnb://host/path1/path2, matchId=1, annotatedElement=com.example.SampleActivity, "
-      + "annotatedMethod=intentFromTwoPath))");
+      + "(UriMatch(uriTemplate=airbnb://host/path1/path2?q={q}, matchId=0, "
+      + "annotatedClassFullyQualifiedName=com.example.SampleActivity, "
+      + "annotatedMethod=intentFromTwoPathWithQuery) vs "
+      + "UriMatch(uriTemplate=airbnb://host/path1/path2, matchId=1, "
+      + "annotatedClassFullyQualifiedName=com.example"
+      + ".SampleActivity, annotatedMethod=intentFromTwoPath))");
   }
 
-  @Test
-  public void uppercasePackage() {
-    JavaFileObject activityWithUppercasePackage = JavaFileObjects
-      .forSourceString("SampleActivity", "package com.Example;"
-        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
-        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
-        + "import com.Example.SampleModule;\n\n"
-        + "@DeepLink(\"airbnb://example.com/deepLink\")"
-        + "@DeepLinkHandler({ SampleModule.class })\n"
-        + "public class SampleActivity {\n"
-        + "}");
-
-    assertAbout(javaSources())
-      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE_UPPERCASE_PACKAGE, activityWithUppercasePackage))
-      .processedWith(new DeepLinkProcessor())
-      .compilesWithoutError()
-      .and()
-      .generatesSources(
-        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.Example."
-            + "SampleModuleRegistry",
-          "package com.Example;\n"
-            + "\n"
-            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-            + "import java.lang.String;\n"
-            + "import java.util.Arrays;\n"
-            + "import java.util.Collections;\n"
-            + "\n"
-            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-            + "  public SampleModuleRegistry() {\n"
-            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", DeepLinkEntry.Type.CLASS,"
-            + "SampleActivity.class, null)\n"
-            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-            + "    new String[]{});\n"
-            + "  }\n"
-            + "\n"
-            + "  private static String matchIndex0() {\n"
-            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00001ÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
-            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
-            + "000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
-            + "}"
-        )
-      );
-  }
+//  @Test
+//  public void uppercasePackage() {
+//    JavaFileObject activityWithUppercasePackage = JavaFileObjects
+//      .forSourceString("SampleActivity", "package com.Example;"
+//        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+//        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
+//        + "import com.Example.SampleModule;\n\n"
+//        + "@DeepLink(\"airbnb://example.com/deepLink\")"
+//        + "@DeepLinkHandler({ SampleModule.class })\n"
+//        + "public class SampleActivity {\n"
+//        + "}");
+//
+//    assertAbout(javaSources())
+//      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE_UPPERCASE_PACKAGE, activityWithUppercasePackage))
+//      .processedWith(new DeepLinkProcessor())
+//      .compilesWithoutError()
+//      .and()
+//      .generatesSources(
+//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.Example."
+//            + "SampleModuleRegistry",
+//          "package com.Example;\n"
+//            + "\n"
+//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
+//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+//            + "import java.lang.String;\n"
+//            + "import java.util.Arrays;\n"
+//            + "import java.util.Collections;\n"
+//            + "\n"
+//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+//            + "  public SampleModuleRegistry() {\n"
+//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
+//            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", "
+//            + "SampleActivity.class, null)\n"
+//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+//            + "    new String[]{});\n"
+//            + "  }\n"
+//            + "\n"
+//            + "  private static String matchIndex0() {\n"
+//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00001ÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
+//            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
+//            + "000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
+//            + "}"
+//        )
+//      );
+//  }
 
   @Test
   public void testNonStaticMethodCompileFail() {
@@ -321,87 +323,87 @@ public class DeepLinkProcessorNonIncrementalTest {
       .withErrorContaining("Prefix property cannot be empty");
   }
 
-  @Test
-  public void testProcessorWithDeepLinkSortRule() {
-    JavaFileObject sampleActivity = JavaFileObjects
-      .forSourceString("SampleActivity", "package com.example;"
-        + "import android.content.Context;\n"
-        + "import android.content.Intent;\n"
-        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
-        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n"
-        + "import com.example.SampleModule;\n\n"
-        + "@DeepLinkHandler({ SampleModule.class })\n"
-        + "public class SampleActivity {\n"
-        + "  @DeepLink(\"airbnb://host/{var}\")"
-        + "  public static Intent intentFromOnePathWithOneParam(Context context){"
-        + "    return new Intent();"
-        + "  }"
-        + "  @DeepLink(\"airbnb://host/path\")"
-        + "  public static Intent intentFromOnePath(Context context){"
-        + "    return new Intent();"
-        + "  }"
-        + "  @DeepLink(\"airbnb://host/path1/path2\")"
-        + "  public static Intent intentFromTwoPath(Context context){"
-        + "    return new Intent();"
-        + "  }"
-        + "  @DeepLink(\"airbnb://host/path1/path3?q={q}\")"
-        + "  public static Intent intentFromTwoPathWithQuery(Context context){"
-        + "    return new Intent();"
-        + "  }"
-        + "  @DeepLink(\"airbnb://host/{var1}/{var2}\")"
-        + "  public static Intent intentFromTwoPathWithTwoParams(Context context){"
-        + "    return new Intent();"
-        + "  }"
-        + "}"
-      );
-
-    assertAbout(javaSources())
-      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
-      .processedWith(new DeepLinkProcessor())
-      .compilesWithoutError()
-      .and()
-      .generatesSources(
-        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example."
-            + "SampleModuleRegistry",
-          "package com.example;\n"
-            + "\n"
-            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-            + "import java.lang.String;\n"
-            + "import java.util.Arrays;\n"
-            + "import java.util.Collections;\n"
-            + "\n"
-            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-            + "  public SampleModuleRegistry() {\n"
-            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-            + "      new DeepLinkEntry(\"airbnb://host/path1/path3?q={q}\", "
-            + "DeepLinkEntry.Type.METHOD, SampleActivity.class, \"intentFromTwoPathWithQuery\"),\n"
-            + "      new DeepLinkEntry(\"airbnb://host/path1/path2\", "
-            + "DeepLinkEntry.Type.METHOD, SampleActivity.class, \"intentFromTwoPath\"),\n"
-            + "      new DeepLinkEntry(\"airbnb://host/{var1}/{var2}\","
-            + " DeepLinkEntry.Type.METHOD, SampleActivity.class,"
-            + " \"intentFromTwoPathWithTwoParams\"),\n"
-            + "      new DeepLinkEntry(\"airbnb://host/path\", "
-            + "DeepLinkEntry.Type.METHOD, SampleActivity.class, \"intentFromOnePath\"),\n"
-            + "      new DeepLinkEntry(\"airbnb://host/{var}\", "
-            + "DeepLinkEntry.Type.METHOD, SampleActivity.class, "
-            + "\"intentFromOnePathWithOneParam\")\n"
-            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-            + "    new String[]{});\n"
-            + "  }\n"
-            + "\n"
-            + "  private static String matchIndex0() {\n"
-            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000vÿÿr\\u0002\\u0006\\u0000\\u0000\\"
-            + "u0000hÿÿairbnb\\u0004\\u0004\\u0000\\u0000\\u0000\\\\ÿÿhost\\b\\u0004\\u0000\\"
-            + "u0000\\u0000\\u0000\\u0000\\u0003path\\b\\u0005\\u0000\\u0000\\u0000\\u001aÿÿpath1\\"
-            + "b\\u0005\\u0000\\u0000\\u0000\\u0000\\u0000\\u0001path2\\b\\u0005\\u0000\\u0000\\"
-            + "u0000\\u0000\\u0000\\u0000path3\\u0018\\u0006\\u0000\\u0000\\u0000\\u000eÿÿ{var1}\\"
-            + "u0018\\u0006\\u0000\\u0000\\u0000\\u0000\\u0000\\u0002{var2}\\u0018\\u0005\\u0000\\"
-            + "u0000\\u0000\\u0000\\u0000\\u0004{var}\";}\n"
-            + "}"));
-  }
+//  @Test
+//  public void testProcessorWithDeepLinkSortRule() {
+//    JavaFileObject sampleActivity = JavaFileObjects
+//      .forSourceString("SampleActivity", "package com.example;"
+//        + "import android.content.Context;\n"
+//        + "import android.content.Intent;\n"
+//        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+//        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n"
+//        + "import com.example.SampleModule;\n\n"
+//        + "@DeepLinkHandler({ SampleModule.class })\n"
+//        + "public class SampleActivity {\n"
+//        + "  @DeepLink(\"airbnb://host/{var}\")"
+//        + "  public static Intent intentFromOnePathWithOneParam(Context context){"
+//        + "    return new Intent();"
+//        + "  }"
+//        + "  @DeepLink(\"airbnb://host/path\")"
+//        + "  public static Intent intentFromOnePath(Context context){"
+//        + "    return new Intent();"
+//        + "  }"
+//        + "  @DeepLink(\"airbnb://host/path1/path2\")"
+//        + "  public static Intent intentFromTwoPath(Context context){"
+//        + "    return new Intent();"
+//        + "  }"
+//        + "  @DeepLink(\"airbnb://host/path1/path3?q={q}\")"
+//        + "  public static Intent intentFromTwoPathWithQuery(Context context){"
+//        + "    return new Intent();"
+//        + "  }"
+//        + "  @DeepLink(\"airbnb://host/{var1}/{var2}\")"
+//        + "  public static Intent intentFromTwoPathWithTwoParams(Context context){"
+//        + "    return new Intent();"
+//        + "  }"
+//        + "}"
+//      );
+//
+//    assertAbout(javaSources())
+//      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
+//      .processedWith(new DeepLinkProcessor())
+//      .compilesWithoutError()
+//      .and()
+//      .generatesSources(
+//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example."
+//            + "SampleModuleRegistry",
+//          "package com.example;\n"
+//            + "\n"
+//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
+//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+//            + "import java.lang.String;\n"
+//            + "import java.util.Arrays;\n"
+//            + "import java.util.Collections;\n"
+//            + "\n"
+//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+//            + "  public SampleModuleRegistry() {\n"
+//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
+//            + "      new DeepLinkEntry(\"airbnb://host/path1/path3?q={q}\", "
+//            + "SampleActivity.class, \"intentFromTwoPathWithQuery\"),\n"
+//            + "      new DeepLinkEntry(\"airbnb://host/path1/path2\", "
+//            + "SampleActivity.class, \"intentFromTwoPath\"),\n"
+//            + "      new DeepLinkEntry(\"airbnb://host/{var1}/{var2}\","
+//            + " SampleActivity.class,"
+//            + " \"intentFromTwoPathWithTwoParams\"),\n"
+//            + "      new DeepLinkEntry(\"airbnb://host/path\", "
+//            + "SampleActivity.class, \"intentFromOnePath\"),\n"
+//            + "      new DeepLinkEntry(\"airbnb://host/{var}\", "
+//            + "SampleActivity.class, "
+//            + "\"intentFromOnePathWithOneParam\")\n"
+//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+//            + "    new String[]{});\n"
+//            + "  }\n"
+//            + "\n"
+//            + "  private static String matchIndex0() {\n"
+//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000vÿÿr\\u0002\\u0006\\u0000\\u0000\\"
+//            + "u0000hÿÿairbnb\\u0004\\u0004\\u0000\\u0000\\u0000\\\\ÿÿhost\\b\\u0004\\u0000\\"
+//            + "u0000\\u0000\\u0000\\u0000\\u0003path\\b\\u0005\\u0000\\u0000\\u0000\\u001aÿÿpath1\\"
+//            + "b\\u0005\\u0000\\u0000\\u0000\\u0000\\u0000\\u0001path2\\b\\u0005\\u0000\\u0000\\"
+//            + "u0000\\u0000\\u0000\\u0000path3\\u0018\\u0006\\u0000\\u0000\\u0000\\u000eÿÿ{var1}\\"
+//            + "u0018\\u0006\\u0000\\u0000\\u0000\\u0000\\u0000\\u0002{var2}\\u0018\\u0005\\u0000\\"
+//            + "u0000\\u0000\\u0000\\u0000\\u0004{var}\";}\n"
+//            + "}"));
+//  }
 
   @Test
   public void testNonAppCompatTaskStackBuilderClassErrorMessage() {

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
@@ -12,7 +12,7 @@ import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
-public class DeepLinkProcessorNonIncrementalTest {
+public class DeepLinkProcessorNonIncrementalTest extends BaseDeepLinkProcessorTest {
   private static final JavaFileObject SIMPLE_DEEPLINK_ACTIVITY = JavaFileObjects
     .forSourceString("SampleActivity", "package com.example;"
       + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
@@ -50,7 +50,7 @@ public class DeepLinkProcessorNonIncrementalTest {
         + "}");
 
     assertAbout(javaSources())
-      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
+      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity, fakeBaseDeeplinkDelegate))
       .processedWith(new DeepLinkProcessor())
       .compilesWithoutError()
       .and()
@@ -111,7 +111,7 @@ public class DeepLinkProcessorNonIncrementalTest {
 
     assertAbout(javaSources())
       .that(Arrays.asList(customAnnotationAppLink, customAnnotationWebLink,
-        SIMPLE_DEEPLINK_MODULE, sampleActivity))
+        SIMPLE_DEEPLINK_MODULE, sampleActivity, fakeBaseDeeplinkDelegate))
       .processedWith(new DeepLinkProcessor())
       .compilesWithoutError()
       .and()
@@ -224,7 +224,7 @@ public class DeepLinkProcessorNonIncrementalTest {
         + "}");
 
     assertAbout(javaSources())
-      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE_UPPERCASE_PACKAGE, activityWithUppercasePackage))
+      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE_UPPERCASE_PACKAGE, activityWithUppercasePackage, fakeBaseDeeplinkDelegate))
       .processedWith(new DeepLinkProcessor())
       .compilesWithoutError()
       .and()
@@ -345,7 +345,7 @@ public class DeepLinkProcessorNonIncrementalTest {
       );
 
     assertAbout(javaSources())
-      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
+      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity, fakeBaseDeeplinkDelegate))
       .processedWith(new DeepLinkProcessor())
       .compilesWithoutError()
       .and()

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
@@ -213,10 +213,10 @@ public class DeepLinkProcessorNonIncrementalTest {
       .processedWith(new DeepLinkProcessor())
       .failsToCompile().withErrorContaining("Internal error during annotation "
       + "processing: java.lang.IllegalStateException: Ambiguous URI. Same match for two URIs "
-      + "(UriMatch(uriTemplate=airbnb://host/path1/path2?q={q}, matchId=0, "
+      + "(UriMatch(uriTemplate=airbnb://host/path1/path2?q={q}, "
       + "annotatedClassFullyQualifiedName=com.example.SampleActivity, "
       + "annotatedMethod=intentFromTwoPathWithQuery) vs "
-      + "UriMatch(uriTemplate=airbnb://host/path1/path2, matchId=1, "
+      + "UriMatch(uriTemplate=airbnb://host/path1/path2, "
       + "annotatedClassFullyQualifiedName=com.example"
       + ".SampleActivity, annotatedMethod=intentFromTwoPath))");
   }

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
@@ -224,7 +224,9 @@ public class DeepLinkProcessorNonIncrementalTest extends BaseDeepLinkProcessorTe
         + "}");
 
     assertAbout(javaSources())
-      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE_UPPERCASE_PACKAGE, activityWithUppercasePackage, fakeBaseDeeplinkDelegate))
+      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE_UPPERCASE_PACKAGE,
+        activityWithUppercasePackage,
+        fakeBaseDeeplinkDelegate))
       .processedWith(new DeepLinkProcessor())
       .compilesWithoutError()
       .and()

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
@@ -37,135 +37,124 @@ public class DeepLinkProcessorNonIncrementalTest {
         + "public class SampleModule {\n"
         + "}");
 
-//  @Test
-//  public void testProcessor() {
-//    JavaFileObject sampleActivity = JavaFileObjects
-//      .forSourceString("SampleActivity", "package com.example;"
-//        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
-//        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
-//        + "import com.example.SampleModule;\n\n"
-//        + "@DeepLink(\"airbnb://example.com/deepLink\")\n"
-//        + "@DeepLinkHandler({ SampleModule.class })\n"
-//        + "public class SampleActivity {\n"
-//        + "}");
-//
-//    assertAbout(javaSources())
-//      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
-//      .processedWith(new DeepLinkProcessor())
-//      .compilesWithoutError()
-//      .and()
-//      .generatesSources(
-//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleRe"
-//            + "gistry",
-//          "package com.example;\n"
-//            + "\n"
-//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-//            + "import java.lang.String;\n"
-//            + "import java.util.Arrays;\n"
-//            + "import java.util.Collections;\n"
-//            + "\n"
-//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-//            + "  public SampleModuleRegistry() {\n"
-//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-//            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", SampleActivity.class,"
-//            + " null)\n"
-//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-//            + "    new String[]{});\n"
-//            + "  }\n"
-//            + "\n"
-//            + "  private static String matchIndex0() {\n"
-//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00001ÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
-//            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
-//            + "000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
-//            + "}"
-//        ));
-//  }
+  @Test
+  public void testProcessor() {
+    JavaFileObject sampleActivity = JavaFileObjects
+      .forSourceString("SampleActivity", "package com.example;"
+        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
+        + "import com.example.SampleModule;\n\n"
+        + "@DeepLink(\"airbnb://example.com/deepLink\")\n"
+        + "@DeepLinkHandler({ SampleModule.class })\n"
+        + "public class SampleActivity {\n"
+        + "}");
 
-//  @Test
-//  public void testProcessorWithDefaultAndCustomAnnotations() {
-//    JavaFileObject customAnnotationWebLink = JavaFileObjects
-//      .forSourceString("WebDeepLink", "package com.example;\n"
-//        + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
-//        + "@DeepLinkSpec(prefix = { \"http://\", \"https://\"})\n"
-//        + "public @interface WebDeepLink {\n"
-//        + "    String[] value();\n"
-//        + "}");
-//    JavaFileObject customAnnotationAppLink = JavaFileObjects
-//      .forSourceString("AppDeepLink", "package com.example;\n"
-//        + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
-//        + "@DeepLinkSpec(prefix = { \"example://\" })\n"
-//        + "public @interface AppDeepLink {\n"
-//        + "    String[] value();\n"
-//        + "}");
-//    JavaFileObject sampleActivity = JavaFileObjects
-//      .forSourceString("SampleActivity", "package com.example;"
-//        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
-//        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
-//        + "import com.example.SampleModule;\n\n"
-//        + "@DeepLink(\"airbnb://example.com/deepLink\")\n"
-//        + "@AppDeepLink({\"example.com/deepLink\",\"example.com/another\"})\n"
-//        + "@WebDeepLink({\"example.com/deepLink\",\"example.com/another\"})\n"
-//        + "@DeepLinkHandler({ SampleModule.class })\n"
-//        + "public class SampleActivity {\n"
-//        + "}");
-//
-//    assertAbout(javaSources())
-//      .that(Arrays.asList(customAnnotationAppLink, customAnnotationWebLink,
-//        SIMPLE_DEEPLINK_MODULE, sampleActivity))
-//      .processedWith(new DeepLinkProcessor())
-//      .compilesWithoutError()
-//      .and()
-//      .generatesSources(
-//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleRegistry",
-//          "package com.example;\n"
-//            + "\n"
-//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-//            + "import java.lang.String;\n"
-//            + "import java.util.Arrays;\n"
-//            + "import java.util.Collections;\n"
-//            + "\n"
-//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-//            + "  public SampleModuleRegistry() {\n"
-//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-//            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", "
-//            + "SampleActivity.class, null),\n"
-//            + "      new DeepLinkEntry(\"example://example.com/another\", "
-//            + "SampleActivity.class, null),\n"
-//            + "      new DeepLinkEntry(\"example://example.com/deepLink\", "
-//            + "SampleActivity.class, null),\n"
-//            + "      new DeepLinkEntry(\"http://example.com/another\", "
-//            + "SampleActivity.class, null),\n"
-//            + "      new DeepLinkEntry(\"http://example.com/deepLink\", "
-//            + "SampleActivity.class, null),\n"
-//            + "      new DeepLinkEntry(\"https://example.com/another\", "
-//            + "SampleActivity.class, null),\n"
-//            + "      new DeepLinkEntry(\"https://example.com/deepLink\", "
-//            + "SampleActivity.class, null)\n"
-//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-//            + "    new String[]{});\n"
-//            + "  }\n"
-//            + "\n"
-//            + "  private static String matchIndex0() {\n"
-//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000ïÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
-//            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
-//            + "000\\u0000\\u0000\\u0000\\u0000deepLink\\u0002\\u0007\\u0000\\u0000\\u00002ÿÿexample"
-//            + "\\u0004\\u000b\\u0000\\u0000\\u0000\\u001fÿÿexample.com\\b\\u0007\\u0000\\u0000\\u00"
-//            + "00\\u0000\\u0000\\u0001another\\b\\b\\u0000\\u0000\\u0000\\u0000\\u0000\\u0002deepLi"
-//            + "nk\\u0002\\u0004\\u0000\\u0000\\u00002ÿÿhttp\\u0004\\u000b\\u0000\\u0000\\u0000\\u00"
-//            + "1fÿÿexample.com\\b\\u0007\\u0000\\u0000\\u0000\\u0000\\u0000\\u0003another\\b\\b\\u0"
-//            + "000\\u0000\\u0000\\u0000\\u0000\\u0004deepLink\\u0002\\u0005\\u0000\\u0000\\u00002ÿÿ"
-//            + "https\\u0004\\u000b\\u0000\\u0000\\u0000\\u001fÿÿexample.com\\b\\u0007\\u0000\\u0000"
-//            + "\\u0000\\u0000\\u0000\\u0005another\\b\\b\\u0000\\u0000\\u0000\\u0000\\u0000\\u0006d"
-//            + "eepLink\";}\n"
-//            + "}"
-//        ));
-//  }
+    assertAbout(javaSources())
+      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
+      .processedWith(new DeepLinkProcessor())
+      .compilesWithoutError()
+      .and()
+      .generatesSources(
+        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleRe"
+            + "gistry",
+          "package com.example;\n"
+            + "\n"
+            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+            + "  public SampleModuleRegistry() {\n"
+            + "    super(Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+            + "    new String[]{});\n"
+            + "  }\n"
+            + "\n"
+            + "  private static String matchIndex0() {\n"
+            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000\\u0000mr\\u0002\\u0006"
+            + "\\u0000\\u0000\\u0000\\u0000\\u0000_airbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0000"
+            + "\\u0000Lexample.com\\b\\b\\u0000<\\u0000\\u0000\\u0000\\u0000deepLink\\u0000"
+            + "\\u001dairbnb://example.com/deepLink\\u0000"
+            + "\\u001acom.example.SampleActivity\\u0000\";\n"
+            + "  }\n"
+            + "}"
+        ));
+  }
+
+  @Test
+  public void testProcessorWithDefaultAndCustomAnnotations() {
+    JavaFileObject customAnnotationWebLink = JavaFileObjects
+      .forSourceString("WebDeepLink", "package com.example;\n"
+        + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
+        + "@DeepLinkSpec(prefix = { \"http://\", \"https://\"})\n"
+        + "public @interface WebDeepLink {\n"
+        + "    String[] value();\n"
+        + "}");
+    JavaFileObject customAnnotationAppLink = JavaFileObjects
+      .forSourceString("AppDeepLink", "package com.example;\n"
+        + "import com.airbnb.deeplinkdispatch.DeepLinkSpec;\n"
+        + "@DeepLinkSpec(prefix = { \"example://\" })\n"
+        + "public @interface AppDeepLink {\n"
+        + "    String[] value();\n"
+        + "}");
+    JavaFileObject sampleActivity = JavaFileObjects
+      .forSourceString("SampleActivity", "package com.example;"
+        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
+        + "import com.example.SampleModule;\n\n"
+        + "@DeepLink(\"airbnb://example.com/deepLink\")\n"
+        + "@AppDeepLink({\"example.com/deepLink\",\"example.com/another\"})\n"
+        + "@WebDeepLink({\"example.com/deepLink\",\"example.com/another\"})\n"
+        + "@DeepLinkHandler({ SampleModule.class })\n"
+        + "public class SampleActivity {\n"
+        + "}");
+
+    assertAbout(javaSources())
+      .that(Arrays.asList(customAnnotationAppLink, customAnnotationWebLink,
+        SIMPLE_DEEPLINK_MODULE, sampleActivity))
+      .processedWith(new DeepLinkProcessor())
+      .compilesWithoutError()
+      .and()
+      .generatesSources(
+        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example.SampleModuleRegistry",
+          "package com.example;\n"
+            + "\n"
+            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+            + "  public SampleModuleRegistry() {\n"
+            + "    super(Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+            + "    new String[]{});\n"
+            + "  }\n"
+            + "\n"
+            + "  private static String matchIndex0() {\n"
+            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000\\u0002\\u008cr\\u0002\\u0006"
+            + "\\u0000\\u0000\\u0000\\u0000\\u0000_airbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0000"
+            + "\\u0000Lexample.com\\b\\b\\u0000<\\u0000\\u0000\\u0000\\u0000deepLink\\u0000"
+            + "\\u001dairbnb://example.com/deepLink\\u0000\\u001acom.example.SampleActivity\\u0000"
+            + "\\u0002\\u0007\\u0000\\u0000\\u0000\\u0000\\u0000«example\\u0004\\u000b\\u0000\\u0000"
+            + "\\u0000\\u0000\\u0000\\u0098example.com\\b\\u0007\\u0000<\\u0000\\u0000\\u0000"
+            + "\\u0000another\\u0000\\u001dexample://example.com/another\\u0000"
+            + "\\u001acom.example.SampleActivity\\u0000\\b\\b\\u0000=\\u0000\\u0000\\u0000"
+            + "\\u0000deepLink\\u0000\\u001eexample://example.com/deepLink\\u0000"
+            + "\\u001acom.example.SampleActivity\\u0000\\u0002\\u0004\\u0000\\u0000\\u0000\\u0000"
+            + "\\u0000¥http\\u0004\\u000b\\u0000\\u0000\\u0000\\u0000\\u0000\\u0092example.com\\b"
+            + "\\u0007\\u00009\\u0000\\u0000\\u0000\\u0000another\\u0000\\u001a"
+            + "http://example.com/another\\u0000\\u001acom.example.SampleActivity\\u0000\\b\\b"
+            + "\\u0000:\\u0000\\u0000\\u0000\\u0000deepLink\\u0000\\u001b"
+            + "http://example.com/deepLink\\u0000\\u001acom.example.SampleActivity\\u0000\\u0002"
+            + "\\u0005\\u0000\\u0000\\u0000\\u0000\\u0000§https\\u0004\\u000b\\u0000\\u0000\\u0000"
+            + "\\u0000\\u0000\\u0094example.com\\b\\u0007\\u0000:\\u0000\\u0000\\u0000\\u0000another"
+            + "\\u0000\\u001bhttps://example.com/another\\u0000\\u001acom.example.SampleActivity"
+            + "\\u0000\\b\\b\\u0000;\\u0000\\u0000\\u0000\\u0000deepLink\\u0000\\u001c"
+            + "https://example.com/deepLink\\u0000\\u001acom.example.SampleActivity\\u0000\";\n"
+            + "  }\n"
+            + "}"
+        ));
+  }
 
   @Test
   public void testDuplicatedUriMatch() {

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
@@ -135,9 +135,9 @@ public class DeepLinkProcessorNonIncrementalTest {
             + "\\u0000\\u0000\\u0000\\u0000\\u0000_airbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0000"
             + "\\u0000Lexample.com\\b\\b\\u0000<\\u0000\\u0000\\u0000\\u0000deepLink\\u0000"
             + "\\u001dairbnb://example.com/deepLink\\u0000\\u001acom.example.SampleActivity\\u0000"
-            + "\\u0002\\u0007\\u0000\\u0000\\u0000\\u0000\\u0000«example\\u0004\\u000b\\u0000\\u0000"
-            + "\\u0000\\u0000\\u0000\\u0098example.com\\b\\u0007\\u0000<\\u0000\\u0000\\u0000"
-            + "\\u0000another\\u0000\\u001dexample://example.com/another\\u0000"
+            + "\\u0002\\u0007\\u0000\\u0000\\u0000\\u0000\\u0000«example\\u0004\\u000b\\u0000"
+            + "\\u0000\\u0000\\u0000\\u0000\\u0098example.com\\b\\u0007\\u0000<\\u0000\\u0000"
+            + "\\u0000\\u0000another\\u0000\\u001dexample://example.com/another\\u0000"
             + "\\u001acom.example.SampleActivity\\u0000\\b\\b\\u0000=\\u0000\\u0000\\u0000"
             + "\\u0000deepLink\\u0000\\u001eexample://example.com/deepLink\\u0000"
             + "\\u001acom.example.SampleActivity\\u0000\\u0002\\u0004\\u0000\\u0000\\u0000\\u0000"
@@ -147,10 +147,11 @@ public class DeepLinkProcessorNonIncrementalTest {
             + "\\u0000:\\u0000\\u0000\\u0000\\u0000deepLink\\u0000\\u001b"
             + "http://example.com/deepLink\\u0000\\u001acom.example.SampleActivity\\u0000\\u0002"
             + "\\u0005\\u0000\\u0000\\u0000\\u0000\\u0000§https\\u0004\\u000b\\u0000\\u0000\\u0000"
-            + "\\u0000\\u0000\\u0094example.com\\b\\u0007\\u0000:\\u0000\\u0000\\u0000\\u0000another"
-            + "\\u0000\\u001bhttps://example.com/another\\u0000\\u001acom.example.SampleActivity"
-            + "\\u0000\\b\\b\\u0000;\\u0000\\u0000\\u0000\\u0000deepLink\\u0000\\u001c"
-            + "https://example.com/deepLink\\u0000\\u001acom.example.SampleActivity\\u0000\";\n"
+            + "\\u0000\\u0000\\u0094example.com\\b\\u0007\\u0000:\\u0000\\u0000\\u0000\\u0000"
+            + "another\\u0000\\u001bhttps://example.com/another\\u0000\\u001acom.example."
+            + "SampleActivity\\u0000\\b\\b\\u0000;\\u0000\\u0000\\u0000\\u0000deepLink\\u0000"
+            + "\\u001chttps://example.com/deepLink\\u0000\\u001acom.example.SampleActivity\\u0000"
+            + "\";\n"
             + "  }\n"
             + "}"
         ));
@@ -210,52 +211,49 @@ public class DeepLinkProcessorNonIncrementalTest {
       + ".SampleActivity, annotatedMethod=intentFromTwoPath))");
   }
 
-//  @Test
-//  public void uppercasePackage() {
-//    JavaFileObject activityWithUppercasePackage = JavaFileObjects
-//      .forSourceString("SampleActivity", "package com.Example;"
-//        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
-//        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
-//        + "import com.Example.SampleModule;\n\n"
-//        + "@DeepLink(\"airbnb://example.com/deepLink\")"
-//        + "@DeepLinkHandler({ SampleModule.class })\n"
-//        + "public class SampleActivity {\n"
-//        + "}");
-//
-//    assertAbout(javaSources())
-//      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE_UPPERCASE_PACKAGE, activityWithUppercasePackage))
-//      .processedWith(new DeepLinkProcessor())
-//      .compilesWithoutError()
-//      .and()
-//      .generatesSources(
-//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.Example."
-//            + "SampleModuleRegistry",
-//          "package com.Example;\n"
-//            + "\n"
-//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-//            + "import java.lang.String;\n"
-//            + "import java.util.Arrays;\n"
-//            + "import java.util.Collections;\n"
-//            + "\n"
-//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-//            + "  public SampleModuleRegistry() {\n"
-//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-//            + "      new DeepLinkEntry(\"airbnb://example.com/deepLink\", "
-//            + "SampleActivity.class, null)\n"
-//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-//            + "    new String[]{});\n"
-//            + "  }\n"
-//            + "\n"
-//            + "  private static String matchIndex0() {\n"
-//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u00001ÿÿr\\u0002\\u0006\\u0000\\u0000\\u0"
-//            + "000#ÿÿairbnb\\u0004\\u000b\\u0000\\u0000\\u0000\\u0010ÿÿexample.com\\b\\b\\u0000\\u0"
-//            + "000\\u0000\\u0000\\u0000\\u0000deepLink\";}\n"
-//            + "}"
-//        )
-//      );
-//  }
+  @Test
+  public void uppercasePackage() {
+    JavaFileObject activityWithUppercasePackage = JavaFileObjects
+      .forSourceString("SampleActivity", "package com.Example;"
+        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n\n"
+        + "import com.Example.SampleModule;\n\n"
+        + "@DeepLink(\"airbnb://example.com/deepLink\")"
+        + "@DeepLinkHandler({ SampleModule.class })\n"
+        + "public class SampleActivity {\n"
+        + "}");
+
+    assertAbout(javaSources())
+      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE_UPPERCASE_PACKAGE, activityWithUppercasePackage))
+      .processedWith(new DeepLinkProcessor())
+      .compilesWithoutError()
+      .and()
+      .generatesSources(
+        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.Example."
+            + "SampleModuleRegistry",
+          "package com.Example;\n"
+            + "\n"
+            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+            + "  public SampleModuleRegistry() {\n"
+            + "    super(Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+            + "    new String[]{});\n"
+            + "  }\n"
+            + "\n"
+            + "  private static String matchIndex0() {\n"
+            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000\\u0000mr\\u0002\\u0006"
+            + "\\u0000\\u0000\\u0000\\u0000\\u0000_airbnb\\u0004\\u000b\\u0000\\u0000\\u0000"
+            + "\\u0000\\u0000Lexample.com\\b\\b\\u0000<\\u0000\\u0000\\u0000\\u0000deepLink"
+            + "\\u0000\\u001dairbnb://example.com/deepLink\\u0000\\u001acom.Example."
+            + "SampleActivity\\u0000\";\n"
+            + "  }\n"
+            + "}"
+        )
+      );
+  }
 
   @Test
   public void testNonStaticMethodCompileFail() {
@@ -312,87 +310,79 @@ public class DeepLinkProcessorNonIncrementalTest {
       .withErrorContaining("Prefix property cannot be empty");
   }
 
-//  @Test
-//  public void testProcessorWithDeepLinkSortRule() {
-//    JavaFileObject sampleActivity = JavaFileObjects
-//      .forSourceString("SampleActivity", "package com.example;"
-//        + "import android.content.Context;\n"
-//        + "import android.content.Intent;\n"
-//        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
-//        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n"
-//        + "import com.example.SampleModule;\n\n"
-//        + "@DeepLinkHandler({ SampleModule.class })\n"
-//        + "public class SampleActivity {\n"
-//        + "  @DeepLink(\"airbnb://host/{var}\")"
-//        + "  public static Intent intentFromOnePathWithOneParam(Context context){"
-//        + "    return new Intent();"
-//        + "  }"
-//        + "  @DeepLink(\"airbnb://host/path\")"
-//        + "  public static Intent intentFromOnePath(Context context){"
-//        + "    return new Intent();"
-//        + "  }"
-//        + "  @DeepLink(\"airbnb://host/path1/path2\")"
-//        + "  public static Intent intentFromTwoPath(Context context){"
-//        + "    return new Intent();"
-//        + "  }"
-//        + "  @DeepLink(\"airbnb://host/path1/path3?q={q}\")"
-//        + "  public static Intent intentFromTwoPathWithQuery(Context context){"
-//        + "    return new Intent();"
-//        + "  }"
-//        + "  @DeepLink(\"airbnb://host/{var1}/{var2}\")"
-//        + "  public static Intent intentFromTwoPathWithTwoParams(Context context){"
-//        + "    return new Intent();"
-//        + "  }"
-//        + "}"
-//      );
-//
-//    assertAbout(javaSources())
-//      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
-//      .processedWith(new DeepLinkProcessor())
-//      .compilesWithoutError()
-//      .and()
-//      .generatesSources(
-//        JavaFileObjects.forResource("DeepLinkDelegate.java"),
-//        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example."
-//            + "SampleModuleRegistry",
-//          "package com.example;\n"
-//            + "\n"
-//            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
-//            + "import com.airbnb.deeplinkdispatch.DeepLinkEntry;\n"
-//            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
-//            + "import java.lang.String;\n"
-//            + "import java.util.Arrays;\n"
-//            + "import java.util.Collections;\n"
-//            + "\n"
-//            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
-//            + "  public SampleModuleRegistry() {\n"
-//            + "    super(Collections.unmodifiableList(Arrays.<DeepLinkEntry>asList(\n"
-//            + "      new DeepLinkEntry(\"airbnb://host/path1/path3?q={q}\", "
-//            + "SampleActivity.class, \"intentFromTwoPathWithQuery\"),\n"
-//            + "      new DeepLinkEntry(\"airbnb://host/path1/path2\", "
-//            + "SampleActivity.class, \"intentFromTwoPath\"),\n"
-//            + "      new DeepLinkEntry(\"airbnb://host/{var1}/{var2}\","
-//            + " SampleActivity.class,"
-//            + " \"intentFromTwoPathWithTwoParams\"),\n"
-//            + "      new DeepLinkEntry(\"airbnb://host/path\", "
-//            + "SampleActivity.class, \"intentFromOnePath\"),\n"
-//            + "      new DeepLinkEntry(\"airbnb://host/{var}\", "
-//            + "SampleActivity.class, "
-//            + "\"intentFromOnePathWithOneParam\")\n"
-//            + "    )), Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
-//            + "    new String[]{});\n"
-//            + "  }\n"
-//            + "\n"
-//            + "  private static String matchIndex0() {\n"
-//            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000vÿÿr\\u0002\\u0006\\u0000\\u0000\\"
-//            + "u0000hÿÿairbnb\\u0004\\u0004\\u0000\\u0000\\u0000\\\\ÿÿhost\\b\\u0004\\u0000\\"
-//            + "u0000\\u0000\\u0000\\u0000\\u0003path\\b\\u0005\\u0000\\u0000\\u0000\\u001aÿÿpath1\\"
-//            + "b\\u0005\\u0000\\u0000\\u0000\\u0000\\u0000\\u0001path2\\b\\u0005\\u0000\\u0000\\"
-//            + "u0000\\u0000\\u0000\\u0000path3\\u0018\\u0006\\u0000\\u0000\\u0000\\u000eÿÿ{var1}\\"
-//            + "u0018\\u0006\\u0000\\u0000\\u0000\\u0000\\u0000\\u0002{var2}\\u0018\\u0005\\u0000\\"
-//            + "u0000\\u0000\\u0000\\u0000\\u0004{var}\";}\n"
-//            + "}"));
-//  }
+  @Test
+  public void testProcessorWithDeepLinkSortRule() {
+    JavaFileObject sampleActivity = JavaFileObjects
+      .forSourceString("SampleActivity", "package com.example;"
+        + "import android.content.Context;\n"
+        + "import android.content.Intent;\n"
+        + "import com.airbnb.deeplinkdispatch.DeepLink;\n"
+        + "import com.airbnb.deeplinkdispatch.DeepLinkHandler;\n"
+        + "import com.example.SampleModule;\n\n"
+        + "@DeepLinkHandler({ SampleModule.class })\n"
+        + "public class SampleActivity {\n"
+        + "  @DeepLink(\"airbnb://host/{var}\")"
+        + "  public static Intent intentFromOnePathWithOneParam(Context context){"
+        + "    return new Intent();"
+        + "  }"
+        + "  @DeepLink(\"airbnb://host/path\")"
+        + "  public static Intent intentFromOnePath(Context context){"
+        + "    return new Intent();"
+        + "  }"
+        + "  @DeepLink(\"airbnb://host/path1/path2\")"
+        + "  public static Intent intentFromTwoPath(Context context){"
+        + "    return new Intent();"
+        + "  }"
+        + "  @DeepLink(\"airbnb://host/path1/path3?q={q}\")"
+        + "  public static Intent intentFromTwoPathWithQuery(Context context){"
+        + "    return new Intent();"
+        + "  }"
+        + "  @DeepLink(\"airbnb://host/{var1}/{var2}\")"
+        + "  public static Intent intentFromTwoPathWithTwoParams(Context context){"
+        + "    return new Intent();"
+        + "  }"
+        + "}"
+      );
+
+    assertAbout(javaSources())
+      .that(Arrays.asList(SIMPLE_DEEPLINK_MODULE, sampleActivity))
+      .processedWith(new DeepLinkProcessor())
+      .compilesWithoutError()
+      .and()
+      .generatesSources(
+        JavaFileObjects.forResource("DeepLinkDelegate.java"),
+        JavaFileObjects.forSourceString("/SOURCE_OUTPUT.com.example."
+            + "SampleModuleRegistry",
+          "package com.example;\n"
+            + "\n"
+            + "import com.airbnb.deeplinkdispatch.BaseRegistry;\n"
+            + "import com.airbnb.deeplinkdispatch.base.Utils;\n"
+            + "import java.lang.String;\n"
+            + "\n"
+            + "public final class SampleModuleRegistry extends BaseRegistry {\n"
+            + "  public SampleModuleRegistry() {\n"
+            + "    super(Utils.readMatchIndexFromStrings( new String[] {matchIndex0(), }),\n"
+            + "    new String[]{});\n"
+            + "  }\n"
+            + "\n"
+            + "  private static String matchIndex0() {\n"
+            + "    return \"\\u0001\\u0001\\u0000\\u0000\\u0000\\u0000\\u0002\\u0000r\\u0002\\u0006"
+            + "\\u0000\\u0000\\u0000\\u0000\\u0001òairbnb\\u0004\\u0004\\u0000\\u0000\\u0000\\u0000"
+            + "\\u0001æhost\\b\\u0004\\u0000B\\u0000\\u0000\\u0000\\u0000path\\u0000\\u0012airbnb:"
+            + "//host/path\\u0000\\u001acom.example.SampleActivity\\u0011intentFromOnePath\\b"
+            + "\\u0005\\u0000\\u0000\\u0000\\u0000\\u0000»path1\\b\\u0005\\u0000I\\u0000\\u0000"
+            + "\\u0000\\u0000path2\\u0000\\u0019airbnb://host/path1/path2\\u0000\\u001acom.example."
+            + "SampleActivity\\u0011intentFromTwoPath\\b\\u0005\\u0000X\\u0000\\u0000\\u0000\\"
+            + "u0000path3\\u0000\\u001fairbnb://host/path1/path3?q={q}\\u0000\\u001acom.example."
+            + "SampleActivity\\u001aintentFromTwoPathWithQuery\\u0018\\u0006\\u0000\\u0000\\u0000"
+            + "\\u0000\\u0000f{var1}\\u0018\\u0006\\u0000X\\u0000\\u0000\\u0000\\u0000{var2}\\u0000"
+            + "\\u001bairbnb://host/{var1}/{var2}\\u0000\\u001acom.example.SampleActivity\\u001e"
+            + "intentFromTwoPathWithTwoParams\\u0018\\u0005\\u0000O\\u0000\\u0000\\u0000\\u0000"
+            + "{var}\\u0000\\u0013airbnb://host/{var}\\u0000\\u001acom.example.SampleActivity"
+            + "\\u001dintentFromOnePathWithOneParam\";\n"
+            + "  }\n"
+            + "}"));
+  }
 
   @Test
   public void testNonAppCompatTaskStackBuilderClassErrorMessage() {

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -179,7 +179,7 @@ public class BaseDeepLinkDelegate {
       Class<?> c = deepLinkEntry.getActivityClass();
       Intent newIntent = null;
       TaskStackBuilder taskStackBuilder = null;
-      if (deepLinkEntry.getType() == DeepLinkEntry.Type.CLASS) {
+      if (deepLinkEntry.getMethod() == null) {
         newIntent = new Intent(activity, c);
       } else {
         Method method;

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.java
@@ -223,14 +223,14 @@ public class BaseDeepLinkDelegateTest {
 
   private static class TestDeepLinkRegistry extends BaseRegistry {
     public TestDeepLinkRegistry(List<DeepLinkEntry> registry) {
-      super(registry, getSearchIndex(registry), new String[]{});
+      super(getSearchIndex(registry), new String[]{});
     }
 
     @NotNull
     private static byte[] getSearchIndex(List<DeepLinkEntry> deepLinkEntries) {
       Root trieRoot = new Root();
-      for (int i = 0; i < deepLinkEntries.size(); i++) {
-        trieRoot.addToTrie(i, deepLinkEntries.get(i).getUriTemplate(), deepLinkEntries.get(i).getActivityClass().getCanonicalName(), deepLinkEntries.get(i).getMethod());
+      for (DeepLinkEntry entry : deepLinkEntries) {
+        trieRoot.addToTrie(entry.getUriTemplate(), entry.getActivityClass().getCanonicalName(), entry.getMethod());
       }
       return trieRoot.toUByteArray();
     }

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.java
@@ -11,7 +11,9 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -138,11 +140,15 @@ public class BaseDeepLinkDelegateTest {
   }
 
   @Test
-  public void testErrorHanderWithDuplicateMartch() {
+  public void testErrorHandlerWithDuplicateMatch() {
     String deeplinkUrl = "airbnb://foo/{bar}";
     String matchUrl = "airbnb://foo/bar";
 
     DeepLinkEntry entry = deepLinkEntry(deeplinkUrl);
+
+    Map<String, String> parametersMap = new HashMap(1);
+    parametersMap.put("bar","bar");
+    entry.setParameters(DeepLinkUri.parse(matchUrl), parametersMap);
 
     Uri uri = mock(Uri.class);
     when(uri.toString())
@@ -201,7 +207,7 @@ public class BaseDeepLinkDelegateTest {
   }
 
   private static DeepLinkEntry deepLinkEntry(String uri) {
-    return new DeepLinkEntry(uri, DeepLinkEntry.Type.CLASS, String.class, null);
+    return new DeepLinkEntry(uri, Object.class, null);
   }
 
   /**
@@ -224,7 +230,7 @@ public class BaseDeepLinkDelegateTest {
     private static byte[] getSearchIndex(List<DeepLinkEntry> deepLinkEntries) {
       Root trieRoot = new Root();
       for (int i = 0; i < deepLinkEntries.size(); i++) {
-        trieRoot.addToTrie(i, DeepLinkUri.parse(deepLinkEntries.get(i).getUriTemplate()), deepLinkEntries.get(i).getActivityClass().toString(), deepLinkEntries.get(i).getMethod());
+        trieRoot.addToTrie(i, deepLinkEntries.get(i).getUriTemplate(), deepLinkEntries.get(i).getActivityClass().getCanonicalName(), deepLinkEntries.get(i).getMethod());
       }
       return trieRoot.toUByteArray();
     }

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -4,7 +4,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -139,14 +140,18 @@ public class DeepLinkEntryTest {
 
   @Test
   public void testEmptyPathPresentParams() throws Exception {
-    DeepLinkEntry entry = deepLinkEntry("dld://foo/{id}");
-    DeepLinkEntry entryNoParam = deepLinkEntry("dld://foo");
+    String urlTemplate = "dld://foo/{id}";
+    String url = "dld://foo";
+
+    DeepLinkEntry entry = deepLinkEntry(urlTemplate);
+    DeepLinkEntry entryNoParam = deepLinkEntry(url);
+    entryNoParam.setParameters(DeepLinkUri.parse(url), Collections.<String, String>emptyMap());
 
     TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
-    DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("dld://foo"));
+    DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse(url));
 
     TestDeepLinkRegistry testRegistryNoParam = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entryNoParam}));
-    DeepLinkEntry matchNoParam = testRegistryNoParam.idxMatch(DeepLinkUri.parse("dld://foo"));
+    DeepLinkEntry matchNoParam = testRegistryNoParam.idxMatch(DeepLinkUri.parse(url));
 
     assertThat(match).isNull();
     assertThat(matchNoParam).isEqualTo(entryNoParam);
@@ -216,19 +221,27 @@ public class DeepLinkEntryTest {
   }
 
   @Test public void pathWithQuotes() {
-    DeepLinkEntry entry = deepLinkEntry("airbnb://s/{query}");
+    String matchTemplate = "airbnb://s/{query}";
+    String matchUrl = "airbnb://s/Sant'Eufemia-a-Maiella--Italia";
+    DeepLinkEntry entry = deepLinkEntry(matchTemplate);
+
+    Map<String, String> parametersMap = new HashMap(1);
+    parametersMap.put("query","Sant'Eufemia-a-Maiella--Italia");
+    entry.setParameters(DeepLinkUri.parse(matchUrl), parametersMap);
 
     TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
-    DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("airbnb://s/Sant'Eufemia-a-Maiella--Italia"));
+    DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse(matchUrl));
 
     assertThat(match).isEqualTo(entry);
   }
 
   @Test public void schemeWithNumbers() {
-    DeepLinkEntry entry = deepLinkEntry("jackson5://example.com");
+    String deeplinkUrl = "jackson5://example.com";
+    DeepLinkEntry entry = deepLinkEntry(deeplinkUrl);
+    entry.setParameters(DeepLinkUri.parse(deeplinkUrl), Collections.<String, String>emptyMap());
 
     TestDeepLinkRegistry testRegistry = getTestRegistry(Arrays.asList(new DeepLinkEntry[] {entry}));
-    DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse("jackson5://example.com"));
+    DeepLinkEntry match = testRegistry.idxMatch(DeepLinkUri.parse(deeplinkUrl));
 
     assertThat(match).isEqualTo(entry);
   }
@@ -270,7 +283,7 @@ public class DeepLinkEntryTest {
   }
 
   private static DeepLinkEntry deepLinkEntry(String uri) {
-    return new DeepLinkEntry(uri, DeepLinkEntry.Type.CLASS, String.class, null);
+    return new DeepLinkEntry(uri, String.class, null);
   }
 
   /**
@@ -292,7 +305,7 @@ public class DeepLinkEntryTest {
     private static byte[] getSearchIndex(List<DeepLinkEntry> registry) {
       Root trieRoot = new Root();
       for (int i = 0; i < registry.size(); i++) {
-        trieRoot.addToTrie(i, DeepLinkUri.parse(registry.get(i).getUriTemplate()),registry.get(i).getActivityClass().toString(), registry.get(i).getMethod());
+        trieRoot.addToTrie(i, registry.get(i).getUriTemplate(),registry.get(i).getActivityClass().getCanonicalName(), registry.get(i).getMethod());
       }
       return trieRoot.toUByteArray();
     }

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.java
@@ -298,14 +298,14 @@ public class DeepLinkEntryTest {
 
   private static class TestDeepLinkRegistry extends BaseRegistry {
     public TestDeepLinkRegistry(List<DeepLinkEntry> registry) {
-      super(registry, getSearchIndex(registry), new String[]{});
+      super(getSearchIndex(registry), new String[]{});
     }
 
     @NotNull
     private static byte[] getSearchIndex(List<DeepLinkEntry> registry) {
       Root trieRoot = new Root();
-      for (int i = 0; i < registry.size(); i++) {
-        trieRoot.addToTrie(i, registry.get(i).getUriTemplate(),registry.get(i).getActivityClass().getCanonicalName(), registry.get(i).getMethod());
+      for (DeepLinkEntry entry : registry) {
+        trieRoot.addToTrie(entry.getUriTemplate(),entry.getActivityClass().getCanonicalName(), entry.getMethod());
       }
       return trieRoot.toUByteArray();
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
     kotlinVersion                : '1.3.72',
-    appCompatVersion             : '1.1.0',
+    appCompatVersion             : '1.2.0',
     localBroadcastManagerVersion : '1.0.0',
     roboelectricVersion          : '4.5.1',
     benchmarkVersion             : '1.0.0'
@@ -8,36 +8,36 @@ def versions = [
 
 ext.versions = versions
 ext.androidConfig = [
-    agpVersion                          : '4.1.2',
+    agpVersion                          : '4.2.0',
     compileSdkVersion                   : 30,
     minSdkVersion                       : 16,
     targetSdkVersion                    : 30
 ]
 
 ext.deps = [
-    autoCommon               : "com.google.auto:auto-common:0.10",
+    autoCommon               : "com.google.auto:auto-common:1.0",
     androidPlugin            : "com.android.tools.build:gradle:$androidConfig.agpVersion",
     appCompat                : "androidx.appcompat:appcompat:$versions.appCompatVersion",
     localBroadcastManager    : "androidx.localbroadcastmanager:localbroadcastmanager:$versions.localBroadcastManagerVersion",
     kotlinStdLib             : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlinVersion",
     kotlinGradlePlugin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinVersion",
-    javaPoet                 : 'com.squareup:javapoet:1.12.1',
+    javaPoet                 : 'com.squareup:javapoet:1.13.0',
     jsr305                   : 'com.google.code.findbugs:jsr305:3.0.2',
-    okio                     : 'com.squareup.okio:okio:1.17.3',
-    androidXAnnotations      : 'androidx.annotation:annotation:1.1.0',
+    okio                     : 'com.squareup.okio:okio:1.17.5',
+    androidXAnnotations      : 'androidx.annotation:annotation:1.2.0',
     // Build and upload with:
     // ./gradlew clean assemble sourcesJar androidSourcesJar javadocsJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
     // Need to use snapshot version and explicitly include javadoc/sources tasks until
     // https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54 is fixed.
-    gradleMavenPublishPlugin : 'com.vanniktech:gradle-maven-publish-plugin:0.11.1',
+    gradleMavenPublishPlugin : 'com.vanniktech:gradle-maven-publish-plugin:0.15.1',
 
     // Testing
-    junit                    : 'junit:junit:4.12',
+    junit                    : 'junit:junit:4.13.2',
     assertJ                  : 'org.assertj:assertj-core:1.7.1',
     roboelectric             : "org.robolectric:robolectric:$versions.roboelectricVersion",
     mockito                  : 'org.mockito:mockito-core:1.10.19',
-    truth                    : 'com.google.truth:truth:0.30',
-    compileTesting           : 'com.google.testing.compile:compile-testing:0.18',
+    truth                    : 'com.google.truth:truth:1.1.2',
+    compileTesting           : 'com.google.testing.compile:compile-testing:0.19',
     android                  : 'com.google.android:android:4.1.1.4',
     benchmark                : "androidx.benchmark:benchmark-junit4:$versions.benchmarkVersion",
     benchmarkGradlePlugin    : "androidx.benchmark:benchmark-gradle-plugin:$versions.benchmarkVersion"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/ConfigurablePathSegmentDeletionTest.kt
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/ConfigurablePathSegmentDeletionTest.kt
@@ -2,8 +2,8 @@ package com.airbnb.deeplinkdispatch.sample
 
 import com.airbnb.deeplinkdispatch.sample.benchmarkable.BenchmarkDeepLinkModuleRegistry
 import com.airbnb.deeplinkdispatch.sample.library.LibraryDeepLinkModuleRegistry
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
-import org.junit.Assert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner


### PR DESCRIPTION
Embed match information into the match index. This way we do not need to codegen all the `DeepLinkEntry` constructions into the generated `DeepLinkRegistry` classes.

This change will create the `DeepLinkEntry` object on the fly with data that is stored inside the index (vs just an id stored in the index that was used to look up the `DeepLinkEntry`).

For this the `matchId` entry was removed from the match index and a new entry which contains the deeplink url template, the class the deeplink is registered in as well as the method to call on that class (if not a class level deeplink) was added.

This leads to 5x speed improvement in index initialization (in our example with 2000 deeplinks index init went from ~12ms down to ~2 ms.

This will also remove the upper boundary for handled deeplinks from DLD as the number of generated `DeepLinkEntry` constructor calls can lead to the Registry classes not being compilable anymore.