### PR TITLE
Enable placeholders in custom annotation prefixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,14 +219,22 @@ public @interface AppDeepLink {
 }
 ```
 
+You can use placeholders (like in paths) in the scheme and host section of prefixes listed in the
+`DeepLinkSpec`. e.g. if you want to match both http and https you can define it like this:
+
 ```java
-// Prefix all web deep links with "http://airbnb.com" and "https://airbnb.com"
-@DeepLinkSpec(prefix = { "http://airbnb.com", "https://airbnb.com" })
+// Match all deeplinks which a scheme staring with "http".
+@DeepLinkSpec(prefix = { "http{url_scheme_suffix}://airbnb.com")
 @Retention(RetentionPolicy.CLASS)
 public @interface WebDeepLink {
   String[] value();
 }
 ```
+
+You will get the value of `url_scheme_suffix` which -- in this case would be "" for http and "s"
+when https is used -- in the extras bundle of your annotated method. If you want to limit which
+values are accepted, you can do that in your annotated method and just return null for the intent
+which will result in a noop.
 
 ```java
 // This activity is gonna handle the following deep links:
@@ -241,6 +249,21 @@ public class CustomPrefixesActivity extends AppCompatActivity {
     //...
 }
 ```
+
+This can be very useful if you want to use it with country prefxes in hostnames e.g.
+
+```java
+// Match all deeplinks that have a scheme starting with http and also match any deeplink that
+// starts with .airbnb.com as well as ones that are only airbnb.com
+@DeepLinkSpec(prefix = { "http{url_scheme_suffix}://{country_prefix}.airbnb.com",
+ "http{url_scheme_suffix}://airbnb.com")
+@Retention(RetentionPolicy.CLASS)
+public @interface WebDeepLink {
+  String[] value();
+}
+```
+
+which saves you from defining a lot prefixes.
 
 ## Usage
 

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
@@ -37,9 +37,12 @@ import java.util.Set;
 import okio.Buffer;
 
 /**
- * Adapted from OkHttp's HttpUrl class. Only change is to allow any scheme, instead of just http or
- * https.
- *https://github.com/square/okhttp/blob/master/okhttp/src/main/java/com/squareup/okhttp/HttpUri.java
+ * Adapted from OkHttp's HttpUrl class. Changes are:
+ *  * Allow any scheme, instead of just http or https.
+ *  * when parsing via parseTemplate(url) allow placeholder chars({}) in url.
+ *
+ * https://github.com/square/okhttp/blob/master/okhttp/src/main/java/com/squareup/okhttp/
+ * HttpUri.java
  */
 public final class DeepLinkUri {
   private static final char[] HEX_DIGITS =
@@ -362,7 +365,7 @@ public final class DeepLinkUri {
   /** Returns the URL that would be retrieved by following {@code link} from this URL. */
   DeepLinkUri resolve(String link) {
     Builder builder = new Builder();
-    Builder.ParseResult result = builder.parse(this, link);
+    Builder.ParseResult result = builder.parse(this, link, false);
     return result == Builder.ParseResult.SUCCESS ? builder.build() : null;
   }
 
@@ -385,8 +388,22 @@ public final class DeepLinkUri {
    * URL, or null if it isn't.
    */
   public static DeepLinkUri parse(String url) {
+    return parse(url, false);
+  }
+
+  /**
+   * Like parse(String url) but allow '{' '}' chars in scheme to allow using placeholders in scheme.
+   *
+   * @param url
+   * @return
+   */
+  public static DeepLinkUri parseTemplate(String url) {
+    return parse(url, true);
+  }
+
+  private static DeepLinkUri parse(String url, boolean allowPlaceholderInSchem) {
     Builder builder = new Builder();
-    Builder.ParseResult result = builder.parse(null, url);
+    Builder.ParseResult result = builder.parse(null, url, allowPlaceholderInSchem);
     return result == Builder.ParseResult.SUCCESS ? builder.build() : null;
   }
 
@@ -407,7 +424,7 @@ public final class DeepLinkUri {
    */
   static DeepLinkUri getChecked(String url) throws MalformedURLException, UnknownHostException {
     Builder builder = new Builder();
-    Builder.ParseResult result = builder.parse(null, url);
+    Builder.ParseResult result = builder.parse(null, url, false);
     switch (result) {
       case SUCCESS:
         return builder.build();
@@ -706,12 +723,15 @@ public final class DeepLinkUri {
       INVALID_HOST,
     }
 
-    ParseResult parse(DeepLinkUri base, String input) {
+    ParseResult parse(DeepLinkUri base, String input, boolean allowPlaceholderInScheme) {
       int pos = skipLeadingAsciiWhitespace(input, 0, input.length());
       int limit = skipTrailingAsciiWhitespace(input, pos, input.length());
 
       // Scheme.
-      int schemeDelimiterOffset = schemeDelimiterOffset(input, pos, limit);
+      int schemeDelimiterOffset = schemeDelimiterOffset(input,
+        pos,
+        limit,
+        allowPlaceholderInScheme);
       if (schemeDelimiterOffset != -1) {
         if (input.regionMatches(true, pos, "https:", 0, 6)) {
           this.scheme = "https";
@@ -956,7 +976,10 @@ public final class DeepLinkUri {
      * Returns the index of the ':' in {@code input} that is after scheme characters. Returns -1 if
      * {@code input} does not have a scheme that starts at {@code pos}.
      */
-    private static int schemeDelimiterOffset(String input, int pos, int limit) {
+    private static int schemeDelimiterOffset(String input,
+                                             int pos,
+                                             int limit,
+                                             boolean allowPlaceholderInScheme) {
       if (limit - pos < 2) return -1;
 
       char c0 = input.charAt(pos);
@@ -966,11 +989,14 @@ public final class DeepLinkUri {
         char c = input.charAt(i);
 
         if ((c >= 'a' && c <= 'z')
-            || (c >= 'A' && c <= 'Z')
-            || (c >= '0' && c <= '9')
-            || c == '+'
-            || c == '-'
-            || c == '.') {
+          || (c >= 'A' && c <= 'Z')
+          || (c >= '0' && c <= '9')
+          || c == '+'
+          || c == '-'
+          || c == '.'
+          || (c == '{' && allowPlaceholderInScheme)
+          || (c == '}' && allowPlaceholderInScheme)
+        ) {
           continue; // Scheme character. Keep going.
         } else if (c == ':') {
           return i; // Scheme prefix!

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
@@ -401,9 +401,9 @@ public final class DeepLinkUri {
     return parse(url, true);
   }
 
-  private static DeepLinkUri parse(String url, boolean allowPlaceholderInSchem) {
+  private static DeepLinkUri parse(String url, boolean allowPlaceholderInScheme) {
     Builder builder = new Builder();
-    Builder.ParseResult result = builder.parse(null, url, allowPlaceholderInSchem);
+    Builder.ParseResult result = builder.parse(null, url, allowPlaceholderInScheme);
     return result == Builder.ParseResult.SUCCESS ? builder.build() : null;
   }
 

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/UrlTree.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/UrlTree.kt
@@ -114,7 +114,7 @@ data class Root(override val id: String = "r") : TreeNode(ROOT_VALUE, NodeMetada
      * Add the given DeepLinkUri to the the trie
      */
     fun addToTrie(deepLinkUriTemplate: String, annotatedClassFullyQualifiedName: String, annotatedMethod: String?) {
-        val deepLinkUri = DeepLinkUri.parse(deepLinkUriTemplate)
+        val deepLinkUri = DeepLinkUri.parseTemplate(deepLinkUriTemplate)
         var node = this.addNode(Scheme(deepLinkUri.scheme().also { validateIfComponentParam(it) }))
         if (!deepLinkUri.host().isNullOrEmpty()) {
             validateIfComponentParam(deepLinkUri.host())

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkAnnotatedElement.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkAnnotatedElement.java
@@ -29,7 +29,7 @@ final class DeepLinkAnnotatedElement {
 
   DeepLinkAnnotatedElement(String annotation, Element element, DeepLinkEntry.Type type)
       throws MalformedURLException {
-    DeepLinkUri url = DeepLinkUri.parse(annotation);
+    DeepLinkUri url = DeepLinkUri.parseTemplate(annotation);
     if (url == null) {
       throw new MalformedURLException("Malformed Uri " + annotation);
     }

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -316,8 +316,8 @@ public class DeepLinkProcessor extends AbstractProcessor {
     Collections.sort(elements, new Comparator<DeepLinkAnnotatedElement>() {
       @Override
       public int compare(DeepLinkAnnotatedElement element1, DeepLinkAnnotatedElement element2) {
-        DeepLinkUri uri1 = DeepLinkUri.parse(element1.getUri());
-        DeepLinkUri uri2 = DeepLinkUri.parse(element2.getUri());
+        DeepLinkUri uri1 = DeepLinkUri.parseTemplate(element1.getUri());
+        DeepLinkUri uri2 = DeepLinkUri.parseTemplate(element2.getUri());
         int comparisonResult = uri2.pathSegments().size() - uri1.pathSegments().size();
         if (comparisonResult == 0) {
           comparisonResult = uri2.queryParameterNames().size() - uri1.queryParameterNames().size();
@@ -351,7 +351,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
         error(element.getAnnotatedElement(), e.getMessage());
       }
 
-      DeepLinkUri deeplinkUri = DeepLinkUri.parse(uri);
+      DeepLinkUri deeplinkUri = DeepLinkUri.parseTemplate(uri);
       //Keep track of pathVariables added in a module so that we can check at runtime to ensure
       //that all pathVariables have a corresponding entry provided to BaseDeepLinkDelegate.
       for (String pathSegment : deeplinkUri.pathSegments()) {

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkAnnotatedElementTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkAnnotatedElementTest.java
@@ -48,4 +48,19 @@ public class DeepLinkAnnotatedElementTest {
     } catch (MalformedURLException ignored) {
     }
   }
+
+  @Test public void testPlaceholderInScheme() throws MalformedURLException {
+    DeepLinkAnnotatedElement annotatedElement = new DeepLinkAnnotatedElement(
+      "http{scheme}://example.com/{foo}/bar", element, DeepLinkEntry.Type.CLASS);
+
+    assertThat(annotatedElement.getUri()).isEqualTo("http{scheme}://example.com/{foo}/bar");
+  }
+
+  @Test public void testPlaceholderInHost() throws MalformedURLException {
+    DeepLinkAnnotatedElement annotatedElement = new DeepLinkAnnotatedElement(
+      "http://{host}example.com/{foo}/bar", element, DeepLinkEntry.Type.CLASS);
+
+    assertThat(annotatedElement.getUri()).isEqualTo("http://{host}example.com/{foo}/bar");
+  }
+
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,6 +32,7 @@ ext.deps = [
     gradleMavenPublishPlugin : 'com.vanniktech:gradle-maven-publish-plugin:0.15.1',
 
     // Testing
+    androidxTestCore         : 'androidx.test:core:1.3.0',
     junit                    : 'junit:junit:4.13.2',
     assertJ                  : 'org.assertj:assertj-core:1.7.1',
     roboelectric             : "org.robolectric:robolectric:$versions.roboelectricVersion",

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   implementation deps.appCompat
   implementation deps.localBroadcastManager
 
+  testImplementation deps.androidxTestCore
   testImplementation deps.roboelectric
   testImplementation deps.junit
 }
@@ -52,6 +53,7 @@ kapt {
     arg("deepLink.customAnnotations",
         "com.airbnb.deeplinkdispatch.sample.AppDeepLink,"
             + "com.airbnb.deeplinkdispatch.sample.WebDeepLink,"
+            + "com.airbnb.deeplinkdispatch.sample.WebPlaceholderDeepLink,"
             + "com.airbnb.deeplinkdispatch.sample.library.LibraryDeepLink"
     )
   }

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivity.java
@@ -14,6 +14,7 @@ import com.airbnb.deeplinkdispatch.sample.library.LibraryDeepLink;
  */
 @AppDeepLink({ "/view_users" })
 @WebDeepLink({ "/users", "/user/{id}" })
+@WebPlaceholderDeepLink({ "/guests", "/guest/{id}" })
 @LibraryDeepLink({ "/library_deeplink", "/library_deeplink/{lib_id}" })
 public class CustomPrefixesActivity extends AppCompatActivity {
   private static final String TAG = CustomPrefixesActivity.class.getSimpleName();

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/WebPlaceholderDeepLink.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/WebPlaceholderDeepLink.java
@@ -1,0 +1,15 @@
+package com.airbnb.deeplinkdispatch.sample;
+
+import com.airbnb.deeplinkdispatch.DeepLinkSpec;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@DeepLinkSpec(prefix = { "http{scheme}://{host_prefix}airbnb.com" })
+// When using tools like Dexguard we require these annotations to still be inside the .dex files
+// produced by D8 but because of this bug https://issuetracker.google.com/issues/168524920 they
+// are not so we need to mark them as RetentionPolicy.RUNTIME.
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WebPlaceholderDeepLink {
+  String[] value();
+}

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivityTest.java
@@ -4,6 +4,8 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.airbnb.deeplinkdispatch.DeepLink;
 import com.google.common.collect.ImmutableList;
 
@@ -11,14 +13,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 @Config(sdk = 21, manifest = "../sample/src/main/AndroidManifest.xml")
@@ -27,7 +28,7 @@ public class CustomPrefixesActivityTest {
   @Test public void testAppDeepLinkIntent() {
     Intent launchedIntent = getLaunchedIntent("app://airbnb/view_users?param=foo");
     assertThat(launchedIntent.getComponent(),
-        equalTo(new ComponentName(RuntimeEnvironment.application, CustomPrefixesActivity.class)));
+        equalTo(new ComponentName(ApplicationProvider.getApplicationContext(), CustomPrefixesActivity.class)));
 
     assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
     assertThat(launchedIntent.getStringExtra(DeepLink.URI),
@@ -40,7 +41,21 @@ public class CustomPrefixesActivityTest {
     for (String uri : cases) {
       Intent launchedIntent = getLaunchedIntent(uri);
       assertThat(launchedIntent.getComponent(),
-          equalTo(new ComponentName(RuntimeEnvironment.application, CustomPrefixesActivity.class)));
+          equalTo(new ComponentName(ApplicationProvider.getApplicationContext(), CustomPrefixesActivity.class)));
+
+      assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+      assertThat(launchedIntent.getStringExtra(DeepLink.URI), equalTo(uri));
+    }
+  }
+
+  @Test
+  public void testWebPlaceholderDeepLinkIntent() {
+    List<String> cases = ImmutableList.of("http://airbnb.com/guests", "https://airbnb.com/guests",
+      "http://de.airbnb.com/guests", "https://de.airbnb.com/guests");
+    for (String uri : cases) {
+      Intent launchedIntent = getLaunchedIntent(uri);
+      assertThat(launchedIntent.getComponent(),
+        equalTo(new ComponentName(ApplicationProvider.getApplicationContext(), CustomPrefixesActivity.class)));
 
       assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
       assertThat(launchedIntent.getStringExtra(DeepLink.URI), equalTo(uri));
@@ -53,7 +68,7 @@ public class CustomPrefixesActivityTest {
     for (String uri : cases) {
       Intent launchedIntent = getLaunchedIntent(uri);
       assertThat(launchedIntent.getComponent(),
-          equalTo(new ComponentName(RuntimeEnvironment.application, CustomPrefixesActivity.class)));
+          equalTo(new ComponentName(ApplicationProvider.getApplicationContext(), CustomPrefixesActivity.class)));
 
       assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
       assertThat(launchedIntent.getStringExtra(DeepLink.URI), equalTo(uri));
@@ -65,7 +80,7 @@ public class CustomPrefixesActivityTest {
     String uri = "library://dld/library_deeplink";
     Intent launchedIntent = getLaunchedIntent(uri);
     assertThat(launchedIntent.getComponent(),
-        equalTo(new ComponentName(RuntimeEnvironment.application, CustomPrefixesActivity.class)));
+        equalTo(new ComponentName(ApplicationProvider.getApplicationContext(), CustomPrefixesActivity.class)));
 
     assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
     assertThat(launchedIntent.getStringExtra(DeepLink.URI), equalTo(uri));
@@ -75,7 +90,7 @@ public class CustomPrefixesActivityTest {
     String uri = "library://dld/library_deeplink/456";
     Intent launchedIntent = getLaunchedIntent(uri);
     assertThat(launchedIntent.getComponent(),
-        equalTo(new ComponentName(RuntimeEnvironment.application, CustomPrefixesActivity.class)));
+        equalTo(new ComponentName(ApplicationProvider.getApplicationContext(), CustomPrefixesActivity.class)));
 
     assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
     assertThat(launchedIntent.getStringExtra(DeepLink.URI), equalTo(uri));

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/CustomPrefixesActivityTest.java
@@ -62,6 +62,35 @@ public class CustomPrefixesActivityTest {
     }
   }
 
+  @Test
+  public void testWebPlaceholderDeepLinkIntentPlaceholderValue() {
+
+    String uri = "https://de.airbnb.com/guests";
+    Intent launchedIntent = getLaunchedIntent(uri);
+    assertThat(launchedIntent.getComponent(),
+      equalTo(new ComponentName(ApplicationProvider.getApplicationContext(), CustomPrefixesActivity.class)));
+
+    assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+    assertThat(launchedIntent.getStringExtra(DeepLink.URI), equalTo(uri));
+    assertThat(launchedIntent.getExtras().getString("scheme"), equalTo("s"));
+    assertThat(launchedIntent.getExtras().getString("host_prefix"), equalTo("de."));
+  }
+
+  @Test
+  public void testWebPlaceholderDeepLinkIntentWihtId() {
+    List<String> cases = ImmutableList.of("http://airbnb.com/guest/123", "https://airbnb.com/guest/123",
+      "http://de.airbnb.com/guest/123", "https://de.airbnb.com/guest/123");
+    for (String uri : cases) {
+      Intent launchedIntent = getLaunchedIntent(uri);
+      assertThat(launchedIntent.getComponent(),
+        equalTo(new ComponentName(ApplicationProvider.getApplicationContext(), CustomPrefixesActivity.class)));
+
+      assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+      assertThat(launchedIntent.getStringExtra(DeepLink.URI), equalTo(uri));
+      assertThat(launchedIntent.getExtras().getString("id"), equalTo("123"));
+    }
+  }
+
   @Test public void testWebDeepLinkIntentWithId() {
     List<String> cases =
         ImmutableList.of("http://airbnb.com/user/123", "https://airbnb.com/user/123");

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
@@ -22,11 +22,11 @@ import org.robolectric.shadows.ShadowApplication;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 @Config(sdk = 21, manifest = "../sample/src/main/AndroidManifest.xml", shadows = {ShadowTaskStackBuilder.class})

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/SecondActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/SecondActivityTest.java
@@ -13,8 +13,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
 import static org.robolectric.Shadows.shadowOf;
 
 @Config(sdk = 21, manifest = "../sample/src/main/AndroidManifest.xml")

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/ShadowTaskStackBuilder.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/ShadowTaskStackBuilder.java
@@ -3,7 +3,8 @@ package com.airbnb.deeplinkdispatch.sample;
 import android.content.Context;
 import android.content.Intent;
 import androidx.core.app.TaskStackBuilder;
-import org.robolectric.RuntimeEnvironment;
+import androidx.test.core.app.ApplicationProvider;
+
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
@@ -38,7 +39,7 @@ public class ShadowTaskStackBuilder {
     intents[0] = new Intent(intents[0]).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK |
         Intent.FLAG_ACTIVITY_CLEAR_TASK |
         Intent.FLAG_ACTIVITY_TASK_ON_HOME);
-    RuntimeEnvironment.application.startActivities(intents);
+    ApplicationProvider.getApplicationContext().startActivities(intents);
   }
 
   @Implementation


### PR DESCRIPTION
This change enables the usage of placeholders in custom annotation prefixes. 

Internally DLD is creating a separate deeplink entry for every deeplink multiplied by the number prefixes.

e.g. if you have 100 places which use your custom `WebDeepLink` which is defined like this:

```java
@DeepLinkSpec(prefix = { "http://example.com", "https://example.com" })
@Retention(RetentionPolicy.RUNTIME)
public @interface WebDeepLink {  String[] value();}
```

it will crate 200 entries as there are 2 prefixes per usage. If you have many prefixes e.g. for country domain differences this can add up and create a lot of entires that are very similar. 

DLD is capable of handling that many entires but it is still not very efficient.

With this change it will allow you to write something like this:

```java
@DeepLinkSpec(prefix = { "http{scheme}://example.com" })
@Retention(RetentionPolicy.RUNTIME)
public @interface WebDeepLink {  String[] value();}
```

This will match `http` and `https` urls (but also basically any url scheme that start with `http` and it will only create one entry in the match index.

If you also have country prefixes for the hosts you can write something like this:

```java
@DeepLinkSpec(prefix = { "http{scheme}://{host_prefix}.example.com" })
@Retention(RetentionPolicy.RUNTIME)
public @interface WebDeepLink {  String[] value();}
```

This will match hosts that are `.*example.com` without having to list them all and still with just one entry in the match index.