### PR TITLE
Allow different Intent/TaskStackBuilder creations for same deeplink

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ public static TaskStackBuilder intentForTaskStackBuilderMethods(Context context)
 }
 ```
 
+If, depending on app state or parameter values you have to either just start an `Intent` or a
+`TaskStackBuilder`, you can return an instance of `DeepLinkMethodResult`. Which can have any.
+The system will pick whichever value is not null but will prefer the `TaskStackBuilder` if both
+are not null.
+
+```java
+@DeepLink("dld://host/methodResult/intent")
+public static DeepLinkMethodResult intentOrTaskStackBuilderViaDeeplinkMethodResult(Context context) {
+  TaskStackBuilder taskStackBuilder = null;
+  Intent intent = null;
+  if (someState) {
+    Intent detailsIntent = new Intent(context, SecondActivity.class);
+    Intent parentIntent = new Intent(context, MainActivity.class);
+    taskStackBuilder = TaskStackBuilder.create(context);
+    taskStackBuilder.addNextIntent(parentIntent);
+    taskStackBuilder.addNextIntent(detailsIntent);
+  } else {
+    intent = new Intent(context, MainActivity.class);
+  }
+  return new DeepLinkMethodResult(intent, taskStackBuilder);
+}
+```
+
 ### Query Parameters
 
 Query parameters are parsed and passed along automatically, and are retrievable like any other parameter. For example, we could retrieve the query parameter passed along in the URI `foo://example.com/deepLink?qp=123`:
@@ -258,7 +281,6 @@ This can be very useful if you want to use it with country prefxes in hostnames 
 @DeepLinkSpec(prefix = { "http{url_scheme_suffix}://{country_prefix}.airbnb.com",
  "http{url_scheme_suffix}://airbnb.com")
 @Retention(RetentionPolicy.CLASS)
-public @interface WebDeepLink {
   String[] value();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ public static TaskStackBuilder intentForTaskStackBuilderMethods(Context context)
 ```
 
 If, depending on app state or parameter values you have to either just start an `Intent` or a
-`TaskStackBuilder`, you can return an instance of `DeepLinkMethodResult`. Which can have any.
+`TaskStackBuilder`, you can return an instance of `DeepLinkMethodResult`, which can have any.
 The system will pick whichever value is not null but will prefer the `TaskStackBuilder` if both
 are not null.
 
@@ -281,6 +281,7 @@ This can be very useful if you want to use it with country prefxes in hostnames 
 @DeepLinkSpec(prefix = { "http{url_scheme_suffix}://{country_prefix}.airbnb.com",
  "http{url_scheme_suffix}://airbnb.com")
 @Retention(RetentionPolicy.CLASS)
+public @interface WebDeepLink {
   String[] value();
 }
 ```

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -201,9 +201,11 @@ public class DeepLinkProcessor extends AbstractProcessor {
         TypeElement returnType = MoreTypes.asTypeElement(executableElement.getReturnType());
         String qualifiedName = returnType.getQualifiedName().toString();
         if (!qualifiedName.equals("android.content.Intent")
-          && !qualifiedName.equals("androidx.core.app.TaskStackBuilder")) {
-          error(element, "Only `Intent` or `androidx.core.app.TaskStackBuilder` are supported."
-            + " Please double check your imports and try again.");
+          && !qualifiedName.equals("androidx.core.app.TaskStackBuilder")
+          && !qualifiedName.equals("com.airbnb.deeplinkdispatch.DeepLinkMethodResult")) {
+          error(element, "Only `Intent`, `androidx.core.app.TaskStackBuilder` or "
+            + "'com.airbnb.deeplinkdispatch.DeepLinkMethodResult' are supported. Please double "
+            + "check your imports and try again.");
         }
       }
 

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorNonIncrementalTest.java
@@ -407,8 +407,9 @@ public class DeepLinkProcessorNonIncrementalTest extends BaseDeepLinkProcessorTe
       .processedWith(new DeepLinkProcessor())
       .failsToCompile()
       .withErrorContaining(
-        "Only `Intent` or `androidx.core.app.TaskStackBuilder` are supported."
-          + " Please double check your imports and try again.");
+        "Only `Intent`, `androidx.core.app.TaskStackBuilder` or "
+          + "'com.airbnb.deeplinkdispatch.DeepLinkMethodResult' are supported. Please double check "
+          + "your imports and try again.");
   }
 
   @Test

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkResult.kt
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkResult.kt
@@ -4,17 +4,14 @@ import android.content.Intent
 import androidx.core.app.TaskStackBuilder
 
 data class DeepLinkResult(
-        /**
-         * @return whether or not the dispatch was a success.
-         */
-        val isSuccessful: Boolean,
-        val uriString: String?,
-        val error: String,
-        /**
-         * The intent for the Deep Link's destination. eg. [com.airbnb.deeplinkdispatch.sample.DeepLinkActivity]
-         */
-        val intent: Intent?,
-        val taskStackBuilder: TaskStackBuilder?, val deepLinkEntry: DeepLinkMatchResult?
+    /**
+     * @return whether or not the dispatch was a success.
+     */
+    val isSuccessful: Boolean,
+    val uriString: String?,
+    val error: String,
+    val deepLinkEntry: DeepLinkMatchResult?,
+    val methodResult: DeepLinkMethodResult
 ) {
     /**
      * This exists so that calls from Kotlin code [error()] are maintained across major version 4.
@@ -30,3 +27,12 @@ data class DeepLinkResult(
                 + '}'.toString())
     }
 }
+
+/**
+ * Can be used to return from any deeplink annotated method. Whatever entry is null will be used.
+ * If both are not null we will use the taskStackBuilder.
+ */
+data class DeepLinkMethodResult(
+    val intent: Intent?,
+    val taskStackBuilder: TaskStackBuilder?
+)

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
@@ -109,7 +109,11 @@ class BaseDeepLinkDelegateTest {
                 .thenReturn(intent)
         val result = testDelegate.createResult(activity, intent, null)
         assertThat(result).isEqualTo(DeepLinkResult(
-                false, null, "No Uri in given activity's intent.", null, null, null))
+            false, null, "No Uri in given activity's intent.", null, DeepLinkMethodResult(
+                null,
+                null
+            )
+        ))
     }
 
     @Test
@@ -132,7 +136,7 @@ class BaseDeepLinkDelegateTest {
                 .thenReturn(appContext)
         val errorHandler = TestErrorHandler()
         val testDelegate = getTwoRegistriesTestDelegate(listOf(entry), listOf(entry), errorHandler)
-        val (_, _, _, _, _, match) = testDelegate.dispatchFrom(activity, intent)
+        val (_, _, _, match) = testDelegate.dispatchFrom(activity, intent)
         assertThat(errorHandler.duplicatedMatchCalled()).isTrue
         assertThat(errorHandler.duplicatedMatches).isNotNull
         assertThat(errorHandler.duplicatedMatches!!.size).isEqualTo(2)
@@ -163,7 +167,7 @@ class BaseDeepLinkDelegateTest {
                 .thenReturn(appContext)
         val errorHandler = TestErrorHandler()
         val testDelegate = getTwoRegistriesTestDelegate(listOf(entry1), listOf(entry2), errorHandler)
-        val (_, _, _, _, _, deepLinkEntry) = testDelegate.dispatchFrom(activity, intent)
+        val (_, _, _, deepLinkEntry) = testDelegate.dispatchFrom(activity, intent)
         assertThat(errorHandler.duplicatedMatchCalled()).isFalse
         assertThat(deepLinkEntry!!.equals(entry2))
     }

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
@@ -113,7 +113,6 @@ public class MainActivity extends AppCompatActivity {
     }
     TaskStackBuilder taskStackBuilder = getTaskStackBuilder(context, ACTION_DEEP_LINK_COMPLEX);
     return taskStackBuilder;
-
   }
 
   @NotNull

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
@@ -23,10 +23,13 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.airbnb.deeplinkdispatch.DeepLink;
+import com.airbnb.deeplinkdispatch.DeepLinkMethodResult;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.TaskStackBuilder;
+
+import org.jetbrains.annotations.NotNull;
 
 @DeepLink({
   "dld://classDeepLink",
@@ -40,6 +43,11 @@ import androidx.core.app.TaskStackBuilder;
 public class MainActivity extends AppCompatActivity {
   private static final String ACTION_DEEP_LINK_METHOD = "deep_link_method";
   private static final String ACTION_DEEP_LINK_COMPLEX = "deep_link_complex";
+  public static final String ACTION_DEEP_LINK_INTENT = "deep_link_intent";
+  public static final String ACTION_DEEP_LINK_TASK_STACK_BUILDER = "deep_link_taskstackbuilder";
+  public static final String ACTION_DEEP_LINK_INTENT_AND_TASK_STACK_BUILDER =
+    "deep_link_intent_and_taskstackbuilder";
+
   private static final String TAG = MainActivity.class.getSimpleName();
 
   @Override protected void onCreate(Bundle savedInstanceState) {
@@ -103,15 +111,21 @@ public class MainActivity extends AppCompatActivity {
     if (bundle != null && bundle.containsKey("qp")) {
       Log.d(TAG, "found new parameter :with query parameter :" + bundle.getString("qp"));
     }
+    TaskStackBuilder taskStackBuilder = getTaskStackBuilder(context, ACTION_DEEP_LINK_COMPLEX);
+    return taskStackBuilder;
+
+  }
+
+  @NotNull
+  private static TaskStackBuilder getTaskStackBuilder(Context context, String action) {
     Intent detailsIntent =
-        new Intent(context, SecondActivity.class).setAction(ACTION_DEEP_LINK_COMPLEX);
+        new Intent(context, SecondActivity.class).setAction(action);
     Intent parentIntent =
-        new Intent(context, MainActivity.class).setAction(ACTION_DEEP_LINK_COMPLEX);
+        new Intent(context, MainActivity.class).setAction(action);
     TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(context);
     taskStackBuilder.addNextIntent(parentIntent);
     taskStackBuilder.addNextIntent(detailsIntent);
     return taskStackBuilder;
-
   }
 
   @DeepLink("dld://host/somePathOne/{arbitraryNumber}/otherPath")
@@ -119,14 +133,42 @@ public class MainActivity extends AppCompatActivity {
     if (bundle != null && bundle.containsKey("qp")) {
       Log.d(TAG, "found new parameter :with query parameter :" + bundle.getString("qp"));
     }
-    return new Intent(context, MainActivity.class).setAction(ACTION_DEEP_LINK_COMPLEX);
+    return new Intent(context, MainActivity.class);
   }
 
+  @DeepLink("dld://host/methodResult/intent")
+  public static DeepLinkMethodResult intentViaDeeplinkMethodResult(Context context) {
+    return new DeepLinkMethodResult(new Intent(context, SecondActivity.class)
+      .setAction(ACTION_DEEP_LINK_INTENT), null);
+  }
+
+  @DeepLink("dld://host/methodResult/intent/{parameter}")
+  public static DeepLinkMethodResult intentViaDeeplinkMethodResult(Context context, Bundle parameter) {
+    return new DeepLinkMethodResult(new Intent(context, SecondActivity.class)
+      .setAction(ACTION_DEEP_LINK_INTENT), null);
+  }
+
+  @DeepLink("dld://host/methodResult/taskStackBuilder")
+  public static
+  DeepLinkMethodResult taskStackBuilderViaDeeplinkMethodResult(Context context) {
+    return new DeepLinkMethodResult(null,
+      getTaskStackBuilder(context, ACTION_DEEP_LINK_TASK_STACK_BUILDER));
+  }
+
+  @DeepLink("dld://host/methodResult/intentAndTaskStackBuilder")
+  public static
+  DeepLinkMethodResult taskStackBuilderAndIntentViaDeeplinkMethodResult(Context context) {
+    return new DeepLinkMethodResult(new Intent(context, SecondActivity.class)
+      .setAction(ACTION_DEEP_LINK_INTENT_AND_TASK_STACK_BUILDER),
+      getTaskStackBuilder(context, ACTION_DEEP_LINK_INTENT_AND_TASK_STACK_BUILDER));
+  }
+
+
   /**
-   * This method is a less concrete match for the URI dld://host/somePathOne/somePathTwo/somePathThree
-   * to a annotated method in `sample-library` that is annotated with
-   * @DeepLink("dld://host/somePathOne/somePathTwo/somePathThree") and thus will always be picked over
-   * this method when matching.
+   * This method is a less concrete match for the URI
+   * dld://host/somePathOne/somePathTwo/somePathThree to a annotated method in `sample-library`
+   * that is annotated with @DeepLink("dld://host/somePathOne/somePathTwo/somePathThree") and thus
+   * will always be picked over this method when matching.
    *
    * @param context
    * @param bundle

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
@@ -55,6 +55,74 @@ public class MainActivityTest {
   }
 
   @Test
+  public void testIntentViaMethodResult() {
+    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://host/methodResult/intent"));
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+      .create().get();
+    ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
+    Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
+    assertThat(launchedIntent.getComponent(),
+      equalTo(new ComponentName(deepLinkActivity, SecondActivity.class)));
+
+    assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+    assertThat(launchedIntent.getAction(), equalTo(MainActivity.ACTION_DEEP_LINK_INTENT));
+  }
+
+  @Test
+  public void testIntentViaMethodResultWithParameter() {
+    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://host/methodResult/intent/someValue"));
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+      .create().get();
+    ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
+    Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
+    assertThat(launchedIntent.getComponent(),
+      equalTo(new ComponentName(deepLinkActivity, SecondActivity.class)));
+
+    assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+    assertThat(launchedIntent.getAction(), equalTo(MainActivity.ACTION_DEEP_LINK_INTENT));
+    assertThat(launchedIntent.getStringExtra("parameter"), equalTo("someValue"));
+  }
+
+  @Test
+  public void testTaskStackBuilderViaMethodResult() {
+    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://host/methodResult/taskStackBuilder"));
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+      .create().get();
+    ShadowApplication shadowApplication = shadowOf(RuntimeEnvironment.application);
+    Intent launchedIntent = shadowApplication.getNextStartedActivity();
+    assertThat(launchedIntent.getComponent(),
+      equalTo(new ComponentName(deepLinkActivity, SecondActivity.class)));
+    assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+    assertThat(launchedIntent.getAction(), equalTo(MainActivity.ACTION_DEEP_LINK_TASK_STACK_BUILDER));
+
+    Intent parentIntent = shadowApplication.getNextStartedActivity();
+    assertNotNull(parentIntent);
+    assertThat(parentIntent.getComponent(),
+      equalTo(new ComponentName(deepLinkActivity, MainActivity.class)));
+    assertThat(parentIntent.getAction(), equalTo(MainActivity.ACTION_DEEP_LINK_TASK_STACK_BUILDER));
+  }
+
+  @Test
+  public void testIntentAndTaskStackBuilderViaMethodResult() {
+    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://host/methodResult/intentAndTaskStackBuilder"));
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+      .create().get();
+    ShadowApplication shadowApplication = shadowOf(RuntimeEnvironment.application);
+    Intent launchedIntent = shadowApplication.getNextStartedActivity();
+    assertThat(launchedIntent.getComponent(),
+      equalTo(new ComponentName(deepLinkActivity, SecondActivity.class)));
+
+    assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+    assertThat(launchedIntent.getAction(), equalTo(MainActivity.ACTION_DEEP_LINK_INTENT_AND_TASK_STACK_BUILDER));
+
+    Intent parentIntent = shadowApplication.getNextStartedActivity();
+    assertNotNull(parentIntent);
+    assertThat(parentIntent.getComponent(),
+      equalTo(new ComponentName(deepLinkActivity, MainActivity.class)));
+    assertThat(parentIntent.getAction(), equalTo(MainActivity.ACTION_DEEP_LINK_INTENT_AND_TASK_STACK_BUILDER));
+  }
+
+  @Test
   public void testPartialSegmentPlaceholderStart() {
     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://example.com/test123bar"));
     DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)


### PR DESCRIPTION
Allow annotated methods to return a `DeeplinkMethodResult`, which is allowing to return either an `Intent` or a `TaskStackBuider` depending on client state (or parameter values).