### PR TITLE
Add functionality to get all DeepLinkEntires from repository

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/BaseRegistry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/BaseRegistry.kt
@@ -49,4 +49,11 @@ abstract class BaseRegistry(matchIndexArray: ByteArray,
                 matchIndex.length(),
                 pathSegmentReplacements)
     }
+
+    /**
+     * Get all DeepLinkEntries that can be matched by this registry
+     */
+    fun getAllEntries(): List<DeepLinkEntry> {
+        return matchIndex.getAllEntries(0, matchIndex.length());
+    }
 }

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
@@ -15,7 +15,12 @@ class DeepLinkMatchTests {
     @Test
     fun testMatchArraySerializationDeserializationNoMethod() {
         val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, this.javaClass.name, null))
-        val entryFromArray = MatchIndex.getMatchResultFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0, DeepLinkUri.parse("schema://none"), emptyMap())
+        val entryFromArray = MatchIndex(matchByteArray.toByteArray()).getMatchResultFromIndex(
+            matchByteArray.size,
+            0,
+            DeepLinkUri.parse("schema://none"),
+            emptyMap()
+        )
         assertNotNull(entryFromArray)
         entryFromArray?.let {
             assertEquals(ONE_PARAM_SCHEMA, it.deeplinkEntry.uriTemplate)
@@ -27,7 +32,12 @@ class DeepLinkMatchTests {
     @Test
     fun testMatchArraySerializationDeserialization() {
         val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, this.javaClass.name, METHOD_NAME))
-        val entryFromArray = MatchIndex.getMatchResultFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0, DeepLinkUri.parse("schema://none"), emptyMap())
+        val entryFromArray = MatchIndex(matchByteArray.toByteArray()).getMatchResultFromIndex(
+            matchByteArray.size,
+            0,
+            DeepLinkUri.parse("schema://none"),
+            emptyMap()
+        )
         assertNotNull(entryFromArray)
         entryFromArray?.let {
             assertEquals(ONE_PARAM_SCHEMA, it.deeplinkEntry.uriTemplate)
@@ -39,11 +49,21 @@ class DeepLinkMatchTests {
     @Test(expected = IllegalStateException::class)
     fun testMatchArraySerializationDeserializationNonExistantClass() {
         val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, "soneNonexistantClass", null))
-        MatchIndex.getMatchResultFromArray(matchByteArray.toByteArray(), matchByteArray.size, 0, DeepLinkUri.parse("schema://none"), emptyMap())
+        MatchIndex(matchByteArray.toByteArray()).getMatchResultFromIndex(
+            matchByteArray.size,
+            0,
+            DeepLinkUri.parse("schema://none"),
+            emptyMap()
+        )
     }
 
     @Test fun testMatchArraySerializationDeserializationNoMatch(){
-        val entryFromArray = MatchIndex.getMatchResultFromArray(ByteArray(0), 0, 0, DeepLinkUri.parse("schema://none"), emptyMap())
+        val entryFromArray = MatchIndex(ByteArray(0)).getMatchResultFromIndex(
+            0,
+            0,
+            DeepLinkUri.parse("schema://none"),
+            emptyMap()
+        )
         assertNull(entryFromArray)
     }
 }

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/MatchIndexTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/MatchIndexTests.kt
@@ -1,0 +1,30 @@
+package com.airbnb.deeplinkdispatch
+
+import com.airbnb.deeplinkdispatch.base.MatchIndex
+import org.assertj.core.api.Assertions
+import org.junit.Test
+
+@kotlin.ExperimentalUnsignedTypes
+class MatchIndexTests {
+
+    @Test
+    fun testGetAllEntries() {
+        val deepLinkEntries = listOf(
+            DeepLinkEntry("http://www.example.com/path1/path2", MatchIndexTests::class.java, "someMethod1"),
+            DeepLinkEntry("https://www.example.com/path1/path2", MatchIndexTests::class.java, "someMethod2"),
+            DeepLinkEntry("dld://dldPath1/dldPath2", MatchIndexTests::class.java, "someMethod3"),
+            DeepLinkEntry("http://example.de/", MatchIndexTests::class.java, "someMethod4"),
+            DeepLinkEntry("http://example.com/path1/path2/path3", MatchIndexTests::class.java, "someMethod5"),
+            DeepLinkEntry("http://example.com/path1/path2", MatchIndexTests::class.java, "someMethod6"),
+            DeepLinkEntry("http://example.com/path1", MatchIndexTests::class.java, "someMethod7"),
+            DeepLinkEntry("http://example.com/", MatchIndexTests::class.java, "someMethod8"),
+        ).sortedBy { it.uriTemplate }
+        val root = Root()
+        deepLinkEntries.forEach{
+            root.addToTrie(it.uriTemplate, it.activityClass.name, it.method)
+        }
+        val matchIndex = MatchIndex(root.toUByteArray().toByteArray())
+        val allEntries = matchIndex.getAllEntries(0, matchIndex.length()).toList().sortedBy { it.uriTemplate }
+        Assertions.assertThat(allEntries).isEqualTo(deepLinkEntries)
+    }
+}

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -345,15 +345,15 @@ public class DeepLinkProcessor extends AbstractProcessor {
       String type = "DeepLinkEntry.Type." + element.getAnnotationType().toString();
       ClassName activity = ClassName.get(element.getAnnotatedElement());
       Object method = element.getMethod();
-      String uri = element.getUri();
+      String uriTemplate = element.getUri();
 
       try {
-        urisTrie.addToTrie(uri, activity.canonicalName(), element.getMethod());
+        urisTrie.addToTrie(uriTemplate, activity.canonicalName(), element.getMethod());
       } catch (IllegalArgumentException e) {
         error(element.getAnnotatedElement(), e.getMessage());
       }
 
-      DeepLinkUri deeplinkUri = DeepLinkUri.parseTemplate(uri);
+      DeepLinkUri deeplinkUri = DeepLinkUri.parseTemplate(uriTemplate);
       //Keep track of pathVariables added in a module so that we can check at runtime to ensure
       //that all pathVariables have a corresponding entry provided to BaseDeepLinkDelegate.
       for (String pathSegment : deeplinkUri.pathSegments()) {

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -325,4 +325,12 @@ public class BaseDeepLinkDelegate {
   public boolean supportsUri(String uriString) {
     return findEntry(uriString) != null;
   }
+
+  public List<DeepLinkEntry> getAllDeepLinkEntries() {
+    List<DeepLinkEntry> resultList = new ArrayList<>();
+    for (BaseRegistry registry : registries) {
+      resultList.addAll(registry.getAllEntries());
+    }
+    return resultList;
+  }
 }


### PR DESCRIPTION
The generated repository classes now do not have any list of all entires in them anymore.
Add functionality to compute that list from the index on demand.