### PR TITLE
Do only load activity class via reflection when it is actually needed.

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/BaseRegistry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/BaseRegistry.kt
@@ -41,13 +41,15 @@ abstract class BaseRegistry(matchIndexArray: ByteArray,
         }
         // Generating a match list (list of elements in to be matched URL starting with an
         // (artificial) root.
-        return matchIndex.matchUri(deepLinkUri,
-                SchemeHostAndPath(deepLinkUri).matchList,
-                emptyMap(),
-                0,
-                0,
-                matchIndex.length(),
-                pathSegmentReplacements)
+        return matchIndex.matchUri(
+            deepLinkUri,
+            SchemeHostAndPath(deepLinkUri).matchList,
+            emptyMap(),
+            0,
+            0,
+            matchIndex.length(),
+            pathSegmentReplacements,
+        )
     }
 
     /**
@@ -56,4 +58,9 @@ abstract class BaseRegistry(matchIndexArray: ByteArray,
     fun getAllEntries(): List<DeepLinkEntry> {
         return matchIndex.getAllEntries(0, matchIndex.length());
     }
+
+    fun supports(
+        deepLinkUri: DeepLinkUri?,
+        pathSegmentReplacements: Map<ByteArray, ByteArray> = mapOf()
+    ) = idxMatch(deepLinkUri, pathSegmentReplacements) != null
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
@@ -31,7 +31,7 @@ data class DeepLinkMatchResult(val deeplinkEntry: DeepLinkEntry,
 
     override fun toString(): String {
         return "uriTemplate: ${deeplinkEntry.uriTemplate} " +
-                "activity: ${deeplinkEntry.activityClass.simpleName} " +
+                "activity: ${deeplinkEntry.activityClass?.simpleName  ?: "not found (name:: ${deeplinkEntry.className})"} " +
                 "method: ${deeplinkEntry.method} " +
                 "parameters: $parameterMap"
     }
@@ -76,19 +76,34 @@ data class DeepLinkMatchResult(val deeplinkEntry: DeepLinkEntry,
     }
 }
 
-data class DeepLinkEntry(val uriTemplate: String,
-                         /**
-                          * The class where the annotation corresponding to where an instance of DeepLinkEntry is declared.
-                          */
-                         val activityClass: Class<*>,
-                         val method: String?) {
+data class DeepLinkEntry(
+    val uriTemplate: String,
+    /**
+     * The class name where the annotation corresponding to where an instance of DeepLinkEntry is declared.
+     */
+    val className: String,
+    val method: String?
+) {
 
     enum class Type {
         CLASS,
         METHOD
     }
 
+    val activityClass: Class<*>? by lazy {
+        try {
+            Class.forName(className)
+        } catch (e: ClassNotFoundException) {
+            println(
+                "Deeplink class " + className + " not found. If you are using Proguard/R8/" +
+                        "Dexguard please consult README.md for correct configuration."
+            )
+            return@lazy null
+        }
+    }
+
     override fun toString(): String {
-        return "uriTemplate: $uriTemplate activity: ${activityClass.simpleName} method: $method"
+        return "uriTemplate: $uriTemplate activity: ${activityClass?.simpleName ?: 
+        "not found (name: ${className})"} method: $method"
     }
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
@@ -2,4 +2,8 @@ package com.airbnb.deeplinkdispatch
 
 interface ErrorHandler {
     fun duplicateMatch(uriString: String, duplicatedMatches: List<DeepLinkMatchResult>)
+
+    fun activityClassNotFound(uriString: String, className: String) {
+        // Empty default implementation
+    }
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -77,7 +77,7 @@ public class MatchIndex {
   public static final char[] VARIABLE_DELIMITER = {'{', '}'};
 
   @NonNull
-  private final byte[] byteArray;
+  public final byte[] byteArray;
 
   public MatchIndex(@NonNull byte[] byteArray) {
     this.byteArray = byteArray;
@@ -160,8 +160,7 @@ public class MatchIndex {
               matchLength,
               getMatchDataPos(currentElementStartPosition),
               deeplinkUri,
-              placeholdersOutput
-            );
+              placeholdersOutput);
           }
         }
       }
@@ -179,7 +178,7 @@ public class MatchIndex {
     List<DeepLinkEntry> resultList = new ArrayList();
     int currentElementStartPosition = elementStartPos;
     do {
-      int matchLength = getMatchLength(elementStartPos);
+      int matchLength = getMatchLength(currentElementStartPosition);
       if (matchLength > 0) {
         resultList.add(getDeepLinkEntryFromIndex(byteArray,
           matchLength,
@@ -225,15 +224,6 @@ public class MatchIndex {
     int classLength = readTwoBytesAsInt(byteArray, position);
     position += MATCH_DATA_CLASS_LENGTH;
     String className = getStringFromByteArray(byteArray, position, classLength);
-    Class deeplinkClass = null;
-    try {
-      deeplinkClass = Class.forName(className);
-    } catch (ClassNotFoundException e) {
-      throw new IllegalStateException(
-        "Deeplink class " + className + " not found. If you are using Proguard/R8/Dexguard please "
-          + "consult README.md for correct configuration.", e
-      );
-    }
     position += classLength;
     int methodLength = readOneByteAsInt(byteArray, position);
     String methodName = null;
@@ -241,7 +231,7 @@ public class MatchIndex {
       position += MATCH_DATA_METHOD_LENGTH;
       methodName = getStringFromByteArray(byteArray, position, methodLength);
     }
-    return new DeepLinkEntry(urlTemplate, deeplinkClass, methodName);
+    return new DeepLinkEntry(urlTemplate, className, methodName);
   }
 
   /**

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchResultTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchResultTests.kt
@@ -5,11 +5,11 @@ import org.junit.Test
 
 class DeepLinkMatchResultTests {
 
-    private val concrete = DeepLinkMatchResult(DeepLinkEntry("scheme://host/one/two/three", this.javaClass, null), emptyMap())
-    private val parmSecondPathElement = DeepLinkMatchResult(DeepLinkEntry("scheme://host/one/{param}/three", this.javaClass, null), emptyMap())
-    private val parmFirstPathElement = DeepLinkMatchResult(DeepLinkEntry("scheme://host/{param}/two/three", this.javaClass, null), emptyMap())
-    private val cpsSecondPathSegment = DeepLinkMatchResult(DeepLinkEntry("scheme://host/one/<config>/three", this.javaClass, null), emptyMap())
-    private val cpsFirstPathSegment = DeepLinkMatchResult(DeepLinkEntry("scheme://host/<config>/two/three", this.javaClass, null), emptyMap())
+    private val concrete = DeepLinkMatchResult(DeepLinkEntry("scheme://host/one/two/three", this.javaClass.name, null), emptyMap())
+    private val parmSecondPathElement = DeepLinkMatchResult(DeepLinkEntry("scheme://host/one/{param}/three", this.javaClass.name, null), emptyMap())
+    private val parmFirstPathElement = DeepLinkMatchResult(DeepLinkEntry("scheme://host/{param}/two/three", this.javaClass.name, null), emptyMap())
+    private val cpsSecondPathSegment = DeepLinkMatchResult(DeepLinkEntry("scheme://host/one/<config>/three", this.javaClass.name, null), emptyMap())
+    private val cpsFirstPathSegment = DeepLinkMatchResult(DeepLinkEntry("scheme://host/<config>/two/three", this.javaClass.name, null), emptyMap())
 
     @Test
     fun testSameness() {

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
@@ -56,7 +56,7 @@ class DeepLinkMatchTests {
             emptyMap()
         )
         assertNotNull(entryFromArray)
-        entryFromArray?.let {
+        entryFromArray!!.let {
             assertEquals(ONE_PARAM_SCHEMA, it.deeplinkEntry.uriTemplate)
             assertEquals("someNonexistantClass", it.deeplinkEntry.className)
             assertNull(it.deeplinkEntry.method)

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
@@ -46,15 +46,21 @@ class DeepLinkMatchTests {
         }
     }
 
-    @Test(expected = IllegalStateException::class)
+    @Test
     fun testMatchArraySerializationDeserializationNonExistantClass() {
-        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, "soneNonexistantClass", null))
-        MatchIndex(matchByteArray.toByteArray()).getMatchResultFromIndex(
+        val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, "someNonexistantClass", null))
+        val entryFromArray = MatchIndex(matchByteArray.toByteArray()).getMatchResultFromIndex(
             matchByteArray.size,
             0,
             DeepLinkUri.parse("schema://none"),
             emptyMap()
         )
+        assertNotNull(entryFromArray)
+        entryFromArray?.let {
+            assertEquals(ONE_PARAM_SCHEMA, it.deeplinkEntry.uriTemplate)
+            assertEquals("someNonexistantClass", it.deeplinkEntry.className)
+            assertNull(it.deeplinkEntry.method)
+        }
     }
 
     @Test fun testMatchArraySerializationDeserializationNoMatch(){

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/MatchIndexTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/MatchIndexTests.kt
@@ -10,21 +10,25 @@ class MatchIndexTests {
     @Test
     fun testGetAllEntries() {
         val deepLinkEntries = listOf(
-            DeepLinkEntry("http://www.example.com/path1/path2", MatchIndexTests::class.java, "someMethod1"),
-            DeepLinkEntry("https://www.example.com/path1/path2", MatchIndexTests::class.java, "someMethod2"),
-            DeepLinkEntry("dld://dldPath1/dldPath2", MatchIndexTests::class.java, "someMethod3"),
-            DeepLinkEntry("http://example.de/", MatchIndexTests::class.java, "someMethod4"),
-            DeepLinkEntry("http://example.com/path1/path2/path3", MatchIndexTests::class.java, "someMethod5"),
-            DeepLinkEntry("http://example.com/path1/path2", MatchIndexTests::class.java, "someMethod6"),
-            DeepLinkEntry("http://example.com/path1", MatchIndexTests::class.java, "someMethod7"),
-            DeepLinkEntry("http://example.com/", MatchIndexTests::class.java, "someMethod8"),
+            DeepLinkEntry("http://www.example.com/somePath1/differentPath2", MatchIndexTests::class.java.name, "someMethod1"),
+            DeepLinkEntry("https://www.example.com/path1/path2", MatchIndexTests::class.java.name, "someMethod2"),
+            DeepLinkEntry("dld://dldPath1/dldPath2", MatchIndexTests::class.java.name, "someMethod3"),
+            DeepLinkEntry("http://example.de/", MatchIndexTests::class.java.name, "someMethod4"),
+            DeepLinkEntry("http://example.com/path1", MatchIndexTests::class.java.name, "someMethod7"),
+            DeepLinkEntry("http://example.com/somethingElse", MatchIndexTests::class.java.name, "someMethod9"),
+            DeepLinkEntry("http://example.com/path1/pathElement2/path3", MatchIndexTests::class.java.name, "someMethod5"),
+            DeepLinkEntry("http://example.com/path1/someOtherPathElement2", MatchIndexTests::class.java.name, "someMethod6"),
+            DeepLinkEntry("http://example.com/", MatchIndexTests::class.java.name, "someMethod8"),
         ).sortedBy { it.uriTemplate }
         val root = Root()
         deepLinkEntries.forEach{
-            root.addToTrie(it.uriTemplate, it.activityClass.name, it.method)
+            root.addToTrie(it.uriTemplate, it.className, it.method)
         }
-        val matchIndex = MatchIndex(root.toUByteArray().toByteArray())
-        val allEntries = matchIndex.getAllEntries(0, matchIndex.length()).toList().sortedBy { it.uriTemplate }
+        val testRegistry = TestRegistry(root.toUByteArray().toByteArray())
+        val allEntries = testRegistry.getAllEntries().sortedBy { it.uriTemplate }
         Assertions.assertThat(allEntries).isEqualTo(deepLinkEntries)
     }
+
+    class TestRegistry(val matchArray: ByteArray) : BaseRegistry(matchArray, emptyArray())
+
 }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -234,6 +234,10 @@ public class BaseDeepLinkDelegate {
             }
           }
         }
+      } else {
+        if (errorHandler != null) {
+          errorHandler.activityClassNotFound(uriString, matchedDeeplinkEntry.getClassName());
+        }
       }
       if (newIntent == null) {
         return new DeepLinkResult(false, uriString, "Destination Intent is null!",
@@ -325,7 +329,6 @@ public class BaseDeepLinkDelegate {
   }
 
   public boolean supportsUri(String uriString) {
-    DeepLinkEntry entryRegExpMatch = null;
     List<DeepLinkMatchResult> entryIdxMatches = new ArrayList<>();
     DeepLinkUri uri = DeepLinkUri.parse(uriString);
     for (BaseRegistry registry : registries) {

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -180,56 +180,58 @@ public class BaseDeepLinkDelegate {
       Class<?> c = matchedDeeplinkEntry.getActivityClass();
       Intent newIntent = null;
       TaskStackBuilder taskStackBuilder = null;
-      if (matchedDeeplinkEntry.getMethod() == null) {
-        newIntent = new Intent(activity, c);
-      } else {
-        Method method;
-        DeepLinkResult errorResult = new DeepLinkResult(false, uriString,
-          "Could not deep link to method: " + matchedDeeplinkEntry.getMethod() + " intents length == 0",
-          deeplinkMatchResult, new DeepLinkMethodResult(null, taskStackBuilder));
-        try {
-          method = c.getMethod(matchedDeeplinkEntry.getMethod(), Context.class);
-          if (method.getReturnType().equals(TaskStackBuilder.class)) {
-            taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity);
-            if (taskStackBuilder.getIntentCount() == 0) {
-              return errorResult;
-            }
-            newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
-          } else if (method.getReturnType().equals(DeepLinkMethodResult.class)) {
-            DeepLinkMethodResult methodResult = (DeepLinkMethodResult) method.invoke(c, activity);
-            if (methodResult.getTaskStackBuilder() != null) {
-              taskStackBuilder = methodResult.getTaskStackBuilder();
+      if(c != null) {
+        if (matchedDeeplinkEntry.getMethod() == null) {
+          newIntent = new Intent(activity, c);
+        } else {
+          Method method;
+          DeepLinkResult errorResult = new DeepLinkResult(false, uriString,
+            "Could not deep link to method: " + matchedDeeplinkEntry.getMethod() + " intents length == 0",
+            deeplinkMatchResult, new DeepLinkMethodResult(null, taskStackBuilder));
+          try {
+            method = c.getMethod(matchedDeeplinkEntry.getMethod(), Context.class);
+            if (method.getReturnType().equals(TaskStackBuilder.class)) {
+              taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity);
               if (taskStackBuilder.getIntentCount() == 0) {
                 return errorResult;
               }
               newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
-            } else if (methodResult.getIntent() != null) {
-              newIntent = methodResult.getIntent();
+            } else if (method.getReturnType().equals(DeepLinkMethodResult.class)) {
+              DeepLinkMethodResult methodResult = (DeepLinkMethodResult) method.invoke(c, activity);
+              if (methodResult.getTaskStackBuilder() != null) {
+                taskStackBuilder = methodResult.getTaskStackBuilder();
+                if (taskStackBuilder.getIntentCount() == 0) {
+                  return errorResult;
+                }
+                newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
+              } else if (methodResult.getIntent() != null) {
+                newIntent = methodResult.getIntent();
+              }
+            } else {
+              newIntent = (Intent) method.invoke(c, activity);
             }
-          } else {
-            newIntent = (Intent) method.invoke(c, activity);
-          }
-        } catch (NoSuchMethodException exception) {
-          method = c.getMethod(matchedDeeplinkEntry.getMethod(), Context.class, Bundle.class);
-          if (method.getReturnType().equals(TaskStackBuilder.class)) {
-            taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity, parameters);
-            if (taskStackBuilder.getIntentCount() == 0) {
-              return errorResult;
-            }
-            newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
-          } else if (method.getReturnType().equals(DeepLinkMethodResult.class)) {
-            DeepLinkMethodResult methodResult = (DeepLinkMethodResult) method.invoke(c, activity, parameters);
-            if (methodResult.getTaskStackBuilder() != null) {
-              taskStackBuilder = methodResult.getTaskStackBuilder();
+          } catch (NoSuchMethodException exception) {
+            method = c.getMethod(matchedDeeplinkEntry.getMethod(), Context.class, Bundle.class);
+            if (method.getReturnType().equals(TaskStackBuilder.class)) {
+              taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity, parameters);
               if (taskStackBuilder.getIntentCount() == 0) {
                 return errorResult;
               }
               newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
-            } else if (methodResult.getIntent() != null) {
-              newIntent = methodResult.getIntent();
+            } else if (method.getReturnType().equals(DeepLinkMethodResult.class)) {
+              DeepLinkMethodResult methodResult = (DeepLinkMethodResult) method.invoke(c, activity, parameters);
+              if (methodResult.getTaskStackBuilder() != null) {
+                taskStackBuilder = methodResult.getTaskStackBuilder();
+                if (taskStackBuilder.getIntentCount() == 0) {
+                  return errorResult;
+                }
+                newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
+              } else if (methodResult.getIntent() != null) {
+                newIntent = methodResult.getIntent();
+              }
+            } else {
+              newIntent = (Intent) method.invoke(c, activity, parameters);
             }
-          } else {
-            newIntent = (Intent) method.invoke(c, activity, parameters);
           }
         }
       }
@@ -323,7 +325,15 @@ public class BaseDeepLinkDelegate {
   }
 
   public boolean supportsUri(String uriString) {
-    return findEntry(uriString) != null;
+    DeepLinkEntry entryRegExpMatch = null;
+    List<DeepLinkMatchResult> entryIdxMatches = new ArrayList<>();
+    DeepLinkUri uri = DeepLinkUri.parse(uriString);
+    for (BaseRegistry registry : registries) {
+      if (registry.supports(uri, configurablePathSegmentReplacements)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public List<DeepLinkEntry> getAllDeepLinkEntries() {

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
@@ -177,7 +177,7 @@ class BaseDeepLinkDelegateTest {
             private fun getSearchIndex(deepLinkEntries: List<DeepLinkEntry>): ByteArray {
                 val trieRoot = Root()
                 for (entry in deepLinkEntries) {
-                    trieRoot.addToTrie(entry.uriTemplate, entry.activityClass.canonicalName!!, entry.method)
+                    trieRoot.addToTrie(entry.uriTemplate, entry.className, entry.method)
                 }
                 return trieRoot.toUByteArray().toByteArray()
             }
@@ -204,7 +204,7 @@ class BaseDeepLinkDelegateTest {
     private class TestDeepLinkDelegate(registries: List<BaseRegistry?>?, errorHandler: ErrorHandler?) : BaseDeepLinkDelegate(registries, errorHandler)
     companion object {
         private fun deepLinkEntry(uri: String): DeepLinkEntry {
-            return DeepLinkEntry(uri, Any::class.java, null)
+            return DeepLinkEntry(uri, Any::class.java.name, null)
         }
 
         /**

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
@@ -134,15 +134,47 @@ class BaseDeepLinkDelegateTest {
                 .thenReturn(intent)
         Mockito.`when`(activity.applicationContext)
                 .thenReturn(appContext)
-        val errorHandler = TestErrorHandler()
+        val errorHandler = DuplicatedMatchTestErrorHandler()
         val testDelegate = getTwoRegistriesTestDelegate(listOf(entry), listOf(entry), errorHandler)
         val (_, _, _, match) = testDelegate.dispatchFrom(activity, intent)
-        assertThat(errorHandler.duplicatedMatchCalled()).isTrue
+        assertThat(errorHandler.duplicateMatchCalled).isTrue
         assertThat(errorHandler.duplicatedMatches).isNotNull
         assertThat(errorHandler.duplicatedMatches!!.size).isEqualTo(2)
         assertThat(errorHandler.duplicatedMatches!![0]).isEqualTo(deeplinkMatchResult)
         assertThat(errorHandler.duplicatedMatches!![1]).isEqualTo(deeplinkMatchResult)
         assertThat(errorHandler.uriString).isEqualTo(matchUrl)
+        assertThat(match).isEqualTo(deeplinkMatchResult)
+    }
+
+    @Test
+    fun testErrorHandlerWithNonExistingClass() {
+        val deeplinkUrl = "airbnb://foo/{bar}"
+        val matchUrl = "airbnb://foo/bar"
+        val className = "nonExistingClassName"
+        val entry = deepLinkEntry(
+            uri = deeplinkUrl,
+            className = className
+        )
+        val deeplinkMatchResult = DeepLinkMatchResult(entry, mapOf(DeepLinkUri.parse(matchUrl) to mapOf("bar" to "bar")))
+        val uri = Mockito.mock(Uri::class.java)
+        Mockito.`when`(uri.toString())
+            .thenReturn(matchUrl)
+        val intent = Mockito.mock(Intent::class.java)
+        Mockito.`when`(intent.data)
+            .thenReturn(uri)
+        val appContext = Mockito.mock(Context::class.java)
+        val activity = Mockito.mock(Activity::class.java)
+        Mockito.`when`(activity.intent)
+            .thenReturn(intent)
+        Mockito.`when`(activity.applicationContext)
+            .thenReturn(appContext)
+        val errorHandler = ClassNotFoundTestErrorHandler()
+        val testDelegate = getOneRegistryTestDelegate(listOf(entry), errorHandler)
+        val (_, _, _, match) = testDelegate.dispatchFrom(activity, intent)
+        assertThat(errorHandler.duplicateMatchCalled).isFalse()
+        assertThat(errorHandler.duplicatedMatches).isNull()
+        assertThat(errorHandler.uriString).isEqualTo(matchUrl)
+        assertThat(errorHandler.className).isEqualTo(className)
         assertThat(match).isEqualTo(deeplinkMatchResult)
     }
 
@@ -165,10 +197,10 @@ class BaseDeepLinkDelegateTest {
                 .thenReturn(intent)
         Mockito.`when`(activity.applicationContext)
                 .thenReturn(appContext)
-        val errorHandler = TestErrorHandler()
+        val errorHandler = DuplicatedMatchTestErrorHandler()
         val testDelegate = getTwoRegistriesTestDelegate(listOf(entry1), listOf(entry2), errorHandler)
         val (_, _, _, deepLinkEntry) = testDelegate.dispatchFrom(activity, intent)
-        assertThat(errorHandler.duplicatedMatchCalled()).isFalse
+        assertThat(errorHandler.duplicateMatchCalled).isFalse
         assertThat(deepLinkEntry!!.equals(entry2))
     }
 
@@ -184,15 +216,11 @@ class BaseDeepLinkDelegateTest {
         }
     }
 
-    private class TestErrorHandler : ErrorHandler {
+    private class DuplicatedMatchTestErrorHandler : ErrorHandler {
+        var className: String = ""
         var duplicatedMatches: List<DeepLinkMatchResult>? = null
-        var duplicateMatchCalled = false
+        var duplicateMatchCalled: Boolean = false
         var uriString: String? = null
-            private set
-
-        fun duplicatedMatchCalled(): Boolean {
-            return duplicateMatchCalled
-        }
 
         override fun duplicateMatch(uriString: String, duplicatedMatches: List<DeepLinkMatchResult>) {
             this.uriString = uriString
@@ -201,10 +229,31 @@ class BaseDeepLinkDelegateTest {
         }
     }
 
+    private class ClassNotFoundTestErrorHandler : ErrorHandler {
+        var className: String = ""
+        var duplicatedMatches: List<DeepLinkMatchResult>? = null
+        var duplicateMatchCalled = false
+        var activityClassNotFound = false
+        var uriString: String? = null
+
+        override fun duplicateMatch(uriString: String, duplicatedMatches: List<DeepLinkMatchResult>) {
+            this.uriString = uriString
+            this.duplicatedMatches = duplicatedMatches
+            duplicateMatchCalled = true
+        }
+
+        override fun activityClassNotFound(uriString: String, className: String) {
+            this.uriString = uriString
+            this.className = className
+            activityClassNotFound = true
+        }
+
+    }
+
     private class TestDeepLinkDelegate(registries: List<BaseRegistry?>?, errorHandler: ErrorHandler?) : BaseDeepLinkDelegate(registries, errorHandler)
     companion object {
-        private fun deepLinkEntry(uri: String): DeepLinkEntry {
-            return DeepLinkEntry(uri, Any::class.java.name, null)
+        private fun deepLinkEntry(uri: String, className: String = Any::class.java.name): DeepLinkEntry {
+            return DeepLinkEntry(uri, className, null)
         }
 
         /**

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.kt
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkEntryTest.kt
@@ -322,6 +322,22 @@ class DeepLinkEntryTest {
         assertThat(matchHttpsDeTld).isNull()
     }
 
+    @Test
+    fun testSupportsWithNonExistantClass() {
+        class NotInAppClassPath {}
+        val deeplinkEntryWithNonExistentClass = deepLinkEntry("http://test.com/", className = "notExisting" )
+        val testRegistry = getTestRegistry(listOf(deeplinkEntryWithNonExistentClass))
+        assertThat(testRegistry.supports(DeepLinkUri.parse("http://test.com/"))).isTrue
+        assertThat(testRegistry.supports(DeepLinkUri.parse("http://false.com/"))).isFalse
+    }
+
+    @Test
+    fun testIdxMatchWithNonExistantClass() {
+        val deeplinkEntryWithNonExistentClass = deepLinkEntry("http://test.com/", className = "notExisting" )
+        val testRegistry = getTestRegistry(listOf(deeplinkEntryWithNonExistentClass))
+        assertThat(testRegistry.idxMatch(DeepLinkUri.parse("http://test.com/"))).isNotNull
+    }
+
     private fun testParametrizedUrl(
         testRegistry: TestDeepLinkRegistry, urlString: String, parameterMap: Map<String, String>
     ) {
@@ -333,11 +349,12 @@ class DeepLinkEntryTest {
     }
 
     private class TestDeepLinkRegistry(registry: List<DeepLinkEntry>) : BaseRegistry(getSearchIndex(registry), arrayOf()) {
+
         companion object {
             private fun getSearchIndex(registry: List<DeepLinkEntry>): ByteArray {
                 val trieRoot = Root()
                 for (entry in registry) {
-                    trieRoot.addToTrie(entry.uriTemplate, entry.activityClass.canonicalName!!, entry.method)
+                    trieRoot.addToTrie(entry.uriTemplate, entry.className, entry.method)
                 }
                 return trieRoot.toUByteArray().toByteArray()
             }
@@ -345,8 +362,8 @@ class DeepLinkEntryTest {
     }
 
     companion object {
-        private fun deepLinkEntry(uri: String): DeepLinkEntry {
-            return DeepLinkEntry(uri, String::class.java, null)
+        private fun deepLinkEntry(uriTemplate: String, className: String = "java.lang.String"): DeepLinkEntry {
+            return DeepLinkEntry(uriTemplate, className, null)
         }
 
         /**


### PR DESCRIPTION
Allow class to be null (can happen when the class is not available to be inflated and handles the same as when the intent cannot route anywhere)

Fix issue with AIOOB when getting allEntries and added tests to catch these kind of errors earlier.