### PR TITLE
Fix inner class matching (matching on methods in inner classes)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        jcenter() // Still needed for some old dependencies
         maven { url "https://oss.sonatype.org/service/local/repositories/snapshots/content/" }
     }
     dependencies {
@@ -14,28 +15,31 @@ buildscript {
         classpath deps.kotlinGradlePlugin
         classpath deps.gradleMavenPublishPlugin
         classpath deps.benchmarkGradlePlugin
+        // Dokka is needed on classpath for vanniktech publish plugin
+        classpath deps.dokkaPlugin
     }
 }
 
 allprojects {
-  apply from: rootProject.file("dependencies.gradle")
+    apply from: rootProject.file("dependencies.gradle")
 
-  repositories {
-    google()
-      mavenCentral()
-  }
+    repositories {
+        google()
+        mavenCentral()
+        jcenter() // Still needed for some old dependencies
+    }
 }
 
 def getReleaseRepositoryUrl() {
-  return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-          : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 }
 
 def getSnapshotRepositoryUrl() {
-  return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-          : "https://oss.sonatype.org/content/repositories/snapshots/"
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : "https://oss.sonatype.org/content/repositories/snapshots/"
 }
 
 def isCi() {
-  project.hasProperty('CI') && CI == 'true'
+    project.hasProperty('CI') && CI == 'true'
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
@@ -31,7 +31,7 @@ data class DeepLinkMatchResult(val deeplinkEntry: DeepLinkEntry,
 
     override fun toString(): String {
         return "uriTemplate: ${deeplinkEntry.uriTemplate} " +
-                "activity: ${deeplinkEntry.activityClass?.simpleName  ?: "not found (name:: ${deeplinkEntry.className})"} " +
+                "activity: ${deeplinkEntry.activityClass.name} " +
                 "method: ${deeplinkEntry.method} " +
                 "parameters: $parameterMap"
     }
@@ -90,20 +90,19 @@ data class DeepLinkEntry(
         METHOD
     }
 
-    val activityClass: Class<*>? by lazy {
+    val activityClass: Class<*> by lazy {
         try {
             Class.forName(className)
         } catch (e: ClassNotFoundException) {
-            println(
-                "Deeplink class " + className + " not found. If you are using Proguard/R8/" +
-                        "Dexguard please consult README.md for correct configuration."
+            throw IllegalStateException(
+                "Deeplink class $className not found. If you are using Proguard" +
+                        "/R8/Dexguard please consult README.md for correct configuration.",
+                e
             )
-            return@lazy null
         }
     }
 
     override fun toString(): String {
-        return "uriTemplate: $uriTemplate activity: ${activityClass?.simpleName ?: 
-        "not found (name: ${className})"} method: $method"
+        return "uriTemplate: $uriTemplate activity: ${activityClass.name} method: $method"
     }
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
@@ -2,8 +2,4 @@ package com.airbnb.deeplinkdispatch
 
 interface ErrorHandler {
     fun duplicateMatch(uriString: String, duplicatedMatches: List<DeepLinkMatchResult>)
-
-    fun activityClassNotFound(uriString: String, className: String) {
-        // Empty default implementation
-    }
 }

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkMatchTests.kt
@@ -3,8 +3,6 @@ package com.airbnb.deeplinkdispatch
 import com.airbnb.deeplinkdispatch.base.MatchIndex
 import junit.framework.TestCase.*
 import org.junit.Test
-import java.lang.IllegalStateException
-
 
 private const val ONE_PARAM_SCHEMA = "scheme://host/one/{param}/three"
 private const val METHOD_NAME = "methodName"
@@ -46,7 +44,7 @@ class DeepLinkMatchTests {
         }
     }
 
-    @Test
+    @Test(expected = IllegalStateException::class)
     fun testMatchArraySerializationDeserializationNonExistantClass() {
         val matchByteArray = matchByteArray(UriMatch(ONE_PARAM_SCHEMA, "someNonexistantClass", null))
         val entryFromArray = MatchIndex(matchByteArray.toByteArray()).getMatchResultFromIndex(
@@ -58,8 +56,8 @@ class DeepLinkMatchTests {
         assertNotNull(entryFromArray)
         entryFromArray!!.let {
             assertEquals(ONE_PARAM_SCHEMA, it.deeplinkEntry.uriTemplate)
-            assertEquals("someNonexistantClass", it.deeplinkEntry.className)
             assertNull(it.deeplinkEntry.method)
+            it.deeplinkEntry.activityClass
         }
     }
 

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.java
@@ -348,7 +348,7 @@ public class DeepLinkProcessor extends AbstractProcessor {
       String uriTemplate = element.getUri();
 
       try {
-        urisTrie.addToTrie(uriTemplate, activity.canonicalName(), element.getMethod());
+        urisTrie.addToTrie(uriTemplate, activity.reflectionName(), element.getMethod());
       } catch (IllegalArgumentException e) {
         error(element.getAnnotatedElement(), e.getMessage());
       }

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -262,7 +262,15 @@ public class BaseDeepLinkDelegate {
     }
   }
 
-  private DeepLinkMatchResult findEntry(String uriString) {
+  /**
+   * Returns a raw match result for the given uriString. This is null if no match is found.
+   * There is no general use for that during normal operation but it might be useful when writing
+   * tests.
+   *
+   * @param uriString Uri to be matched
+   * @return An instance of {@link DeepLinkMatchResult} if a match was found or null if not.
+   */
+  public @Nullable DeepLinkMatchResult findEntry(@NonNull String uriString) {
     DeepLinkEntry entryRegExpMatch = null;
     List<DeepLinkMatchResult> entryIdxMatches = new ArrayList<>();
     DeepLinkUri uri = DeepLinkUri.parse(uriString);

--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.java
@@ -180,63 +180,57 @@ public class BaseDeepLinkDelegate {
       Class<?> c = matchedDeeplinkEntry.getActivityClass();
       Intent newIntent = null;
       TaskStackBuilder taskStackBuilder = null;
-      if(c != null) {
-        if (matchedDeeplinkEntry.getMethod() == null) {
-          newIntent = new Intent(activity, c);
-        } else {
-          Method method;
-          DeepLinkResult errorResult = new DeepLinkResult(false, uriString,
-            "Could not deep link to method: " + matchedDeeplinkEntry.getMethod() + " intents length == 0",
-            deeplinkMatchResult, new DeepLinkMethodResult(null, taskStackBuilder));
-          try {
-            method = c.getMethod(matchedDeeplinkEntry.getMethod(), Context.class);
-            if (method.getReturnType().equals(TaskStackBuilder.class)) {
-              taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity);
-              if (taskStackBuilder.getIntentCount() == 0) {
-                return errorResult;
-              }
-              newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
-            } else if (method.getReturnType().equals(DeepLinkMethodResult.class)) {
-              DeepLinkMethodResult methodResult = (DeepLinkMethodResult) method.invoke(c, activity);
-              if (methodResult.getTaskStackBuilder() != null) {
-                taskStackBuilder = methodResult.getTaskStackBuilder();
-                if (taskStackBuilder.getIntentCount() == 0) {
-                  return errorResult;
-                }
-                newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
-              } else if (methodResult.getIntent() != null) {
-                newIntent = methodResult.getIntent();
-              }
-            } else {
-              newIntent = (Intent) method.invoke(c, activity);
-            }
-          } catch (NoSuchMethodException exception) {
-            method = c.getMethod(matchedDeeplinkEntry.getMethod(), Context.class, Bundle.class);
-            if (method.getReturnType().equals(TaskStackBuilder.class)) {
-              taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity, parameters);
-              if (taskStackBuilder.getIntentCount() == 0) {
-                return errorResult;
-              }
-              newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
-            } else if (method.getReturnType().equals(DeepLinkMethodResult.class)) {
-              DeepLinkMethodResult methodResult = (DeepLinkMethodResult) method.invoke(c, activity, parameters);
-              if (methodResult.getTaskStackBuilder() != null) {
-                taskStackBuilder = methodResult.getTaskStackBuilder();
-                if (taskStackBuilder.getIntentCount() == 0) {
-                  return errorResult;
-                }
-                newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
-              } else if (methodResult.getIntent() != null) {
-                newIntent = methodResult.getIntent();
-              }
-            } else {
-              newIntent = (Intent) method.invoke(c, activity, parameters);
-            }
-          }
-        }
+      if (matchedDeeplinkEntry.getMethod() == null) {
+        newIntent = new Intent(activity, c);
       } else {
-        if (errorHandler != null) {
-          errorHandler.activityClassNotFound(uriString, matchedDeeplinkEntry.getClassName());
+        Method method;
+        DeepLinkResult errorResult = new DeepLinkResult(false, uriString,
+          "Could not deep link to method: " + matchedDeeplinkEntry.getMethod() + " intents length == 0",
+          deeplinkMatchResult, new DeepLinkMethodResult(null, taskStackBuilder));
+        try {
+          method = c.getMethod(matchedDeeplinkEntry.getMethod(), Context.class);
+          if (method.getReturnType().equals(TaskStackBuilder.class)) {
+            taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity);
+            if (taskStackBuilder.getIntentCount() == 0) {
+              return errorResult;
+            }
+            newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
+          } else if (method.getReturnType().equals(DeepLinkMethodResult.class)) {
+            DeepLinkMethodResult methodResult = (DeepLinkMethodResult) method.invoke(c, activity);
+            if (methodResult.getTaskStackBuilder() != null) {
+              taskStackBuilder = methodResult.getTaskStackBuilder();
+              if (taskStackBuilder.getIntentCount() == 0) {
+                return errorResult;
+              }
+              newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
+            } else if (methodResult.getIntent() != null) {
+              newIntent = methodResult.getIntent();
+            }
+          } else {
+            newIntent = (Intent) method.invoke(c, activity);
+          }
+        } catch (NoSuchMethodException exception) {
+          method = c.getMethod(matchedDeeplinkEntry.getMethod(), Context.class, Bundle.class);
+          if (method.getReturnType().equals(TaskStackBuilder.class)) {
+            taskStackBuilder = (TaskStackBuilder) method.invoke(c, activity, parameters);
+            if (taskStackBuilder.getIntentCount() == 0) {
+              return errorResult;
+            }
+            newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
+          } else if (method.getReturnType().equals(DeepLinkMethodResult.class)) {
+            DeepLinkMethodResult methodResult = (DeepLinkMethodResult) method.invoke(c, activity, parameters);
+            if (methodResult.getTaskStackBuilder() != null) {
+              taskStackBuilder = methodResult.getTaskStackBuilder();
+              if (taskStackBuilder.getIntentCount() == 0) {
+                return errorResult;
+              }
+              newIntent = taskStackBuilder.editIntentAt(taskStackBuilder.getIntentCount() - 1);
+            } else if (methodResult.getIntent() != null) {
+              newIntent = methodResult.getIntent();
+            }
+          } else {
+            newIntent = (Intent) method.invoke(c, activity, parameters);
+          }
         }
       }
       if (newIntent == null) {

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
@@ -147,38 +147,6 @@ class BaseDeepLinkDelegateTest {
     }
 
     @Test
-    fun testErrorHandlerWithNonExistingClass() {
-        val deeplinkUrl = "airbnb://foo/{bar}"
-        val matchUrl = "airbnb://foo/bar"
-        val className = "nonExistingClassName"
-        val entry = deepLinkEntry(
-            uri = deeplinkUrl,
-            className = className
-        )
-        val deeplinkMatchResult = DeepLinkMatchResult(entry, mapOf(DeepLinkUri.parse(matchUrl) to mapOf("bar" to "bar")))
-        val uri = Mockito.mock(Uri::class.java)
-        Mockito.`when`(uri.toString())
-            .thenReturn(matchUrl)
-        val intent = Mockito.mock(Intent::class.java)
-        Mockito.`when`(intent.data)
-            .thenReturn(uri)
-        val appContext = Mockito.mock(Context::class.java)
-        val activity = Mockito.mock(Activity::class.java)
-        Mockito.`when`(activity.intent)
-            .thenReturn(intent)
-        Mockito.`when`(activity.applicationContext)
-            .thenReturn(appContext)
-        val errorHandler = ClassNotFoundTestErrorHandler()
-        val testDelegate = getOneRegistryTestDelegate(listOf(entry), errorHandler)
-        val (_, _, _, match) = testDelegate.dispatchFrom(activity, intent)
-        assertThat(errorHandler.duplicateMatchCalled).isFalse()
-        assertThat(errorHandler.duplicatedMatches).isNull()
-        assertThat(errorHandler.uriString).isEqualTo(matchUrl)
-        assertThat(errorHandler.className).isEqualTo(className)
-        assertThat(match).isEqualTo(deeplinkMatchResult)
-    }
-
-    @Test
     fun testErrorHandlerNotGettingCalled() {
         val deeplinkUrl1 = "airbnb://foo/{bar}"
         val deeplinkUrl2 = "airbnb://bar/{foo}"
@@ -227,27 +195,6 @@ class BaseDeepLinkDelegateTest {
             this.duplicatedMatches = duplicatedMatches
             duplicateMatchCalled = true
         }
-    }
-
-    private class ClassNotFoundTestErrorHandler : ErrorHandler {
-        var className: String = ""
-        var duplicatedMatches: List<DeepLinkMatchResult>? = null
-        var duplicateMatchCalled = false
-        var activityClassNotFound = false
-        var uriString: String? = null
-
-        override fun duplicateMatch(uriString: String, duplicatedMatches: List<DeepLinkMatchResult>) {
-            this.uriString = uriString
-            this.duplicatedMatches = duplicatedMatches
-            duplicateMatchCalled = true
-        }
-
-        override fun activityClassNotFound(uriString: String, className: String) {
-            this.uriString = uriString
-            this.className = className
-            activityClassNotFound = true
-        }
-
     }
 
     private class TestDeepLinkDelegate(registries: List<BaseRegistry?>?, errorHandler: ErrorHandler?) : BaseDeepLinkDelegate(registries, errorHandler)

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
@@ -10,6 +10,21 @@ import org.mockito.Mockito
 
 @kotlin.ExperimentalUnsignedTypes
 class BaseDeepLinkDelegateTest {
+
+    @Test
+    fun testFindEntry() {
+        val entry = deepLinkEntry("airbnb://foo/{bar}")
+        val testDelegate = getOneRegistryTestDelegate(listOf(entry), null)
+        val foundEntry = testDelegate.findEntry("airbnb://foo/1")
+        assertThat(foundEntry).isNotNull
+        assertThat(foundEntry?.deeplinkEntry).isEqualTo(entry)
+        assertThat(foundEntry?.parameterMap).isEqualTo(parameterMap(
+            "airbnb://foo/1",
+            mapOf("bar" to "1")
+        ))
+        assertThat( testDelegate.findEntry("airbnb://bar/1")).isNull()
+    }
+
     @Test
     fun testDispatchNullActivity() {
         val entry = deepLinkEntry("airbnb://foo/{bar}")
@@ -183,6 +198,11 @@ class BaseDeepLinkDelegateTest {
             }
         }
     }
+
+    private fun parameterMap(
+        url: String,
+        parameterMap: Map<String, String>
+    ) = mapOf(DeepLinkUri.parse(url) to parameterMap)
 
     private class DuplicatedMatchTestErrorHandler : ErrorHandler {
         var className: String = ""

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,7 +27,8 @@ ext.deps = [
     androidXAnnotations      : 'androidx.annotation:annotation:1.2.0',
     // Build and upload with:
     // ./gradlew clean assemble sourcesJar androidSourcesJar javadocsJar androidJavadocsJar uploadArchives --no-daemon --no-parallel
-    gradleMavenPublishPlugin : 'com.vanniktech:gradle-maven-publish-plugin:0.12.0',
+    gradleMavenPublishPlugin : 'com.vanniktech:gradle-maven-publish-plugin:0.14.2',
+    dokkaPlugin              : 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.30',
 
     // Testing
     androidxTestCore         : 'androidx.test:core:1.3.0',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 def versions = [
-    kotlinVersion                : '1.5.0',
+    kotlinVersion                : '1.5.10',
     appCompatVersion             : '1.2.0',
     localBroadcastManagerVersion : '1.0.0',
     roboelectricVersion          : '4.5.1',
@@ -8,7 +8,7 @@ def versions = [
 
 ext.versions = versions
 ext.androidConfig = [
-    agpVersion                          : '4.2.0',
+    agpVersion                          : '4.2.1',
     compileSdkVersion                   : 30,
     minSdkVersion                       : 16,
     targetSdkVersion                    : 30

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip

--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
@@ -43,12 +43,20 @@ import org.jetbrains.annotations.NotNull;
 public class MainActivity extends AppCompatActivity {
   private static final String ACTION_DEEP_LINK_METHOD = "deep_link_method";
   private static final String ACTION_DEEP_LINK_COMPLEX = "deep_link_complex";
+  public static final String ACTION_DEEP_LINK_INNER = "deep_link_inner";
   public static final String ACTION_DEEP_LINK_INTENT = "deep_link_intent";
   public static final String ACTION_DEEP_LINK_TASK_STACK_BUILDER = "deep_link_taskstackbuilder";
   public static final String ACTION_DEEP_LINK_INTENT_AND_TASK_STACK_BUILDER =
     "deep_link_intent_and_taskstackbuilder";
 
   private static final String TAG = MainActivity.class.getSimpleName();
+
+  public static class InnerClass {
+    @DeepLink("dld://innerClassDeeplink")
+    public static Intent intentForDeepLinkMethod(Context context) {
+      return new Intent(context, SecondActivity.class).setAction(ACTION_DEEP_LINK_INNER);
+    }
+  }
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -64,6 +72,8 @@ public class MainActivity extends AppCompatActivity {
         toastMessage = "method with param1:" + parameters.getString("param1");
       } else if (ACTION_DEEP_LINK_COMPLEX.equals(intent.getAction())) {
         toastMessage = parameters.getString("arbitraryNumber");
+      } else if (ACTION_DEEP_LINK_INNER.equals(intent.getAction())) {
+        toastMessage = "Deeplink on method in inner class";
       } else if (parameters.containsKey("arg")) {
         toastMessage = "class and found arg:" + parameters.getString("arg");
       } else {

--- a/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
+++ b/sample/src/test/java/com/airbnb/deeplinkdispatch/sample/MainActivityTest.java
@@ -69,6 +69,20 @@ public class MainActivityTest {
   }
 
   @Test
+  public void testIntentViaInnerClassMethodResult() {
+    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://innerClassDeeplink"));
+    DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)
+      .create().get();
+    ShadowActivity shadowActivity = shadowOf(deepLinkActivity);
+    Intent launchedIntent = shadowActivity.peekNextStartedActivityForResult().intent;
+    assertThat(launchedIntent.getComponent(),
+      equalTo(new ComponentName(deepLinkActivity, SecondActivity.class)));
+
+    assertThat(launchedIntent.getBooleanExtra(DeepLink.IS_DEEP_LINK, false), equalTo(true));
+    assertThat(launchedIntent.getAction(), equalTo(MainActivity.ACTION_DEEP_LINK_INNER));
+  }
+
+  @Test
   public void testIntentViaMethodResultWithParameter() {
     Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("dld://host/methodResult/intent/someValue"));
     DeepLinkActivity deepLinkActivity = Robolectric.buildActivity(DeepLinkActivity.class, intent)


### PR DESCRIPTION
- Add test to test inner class matching
- Remove nullability of activity class and throw exception (and crash) if class does not exist as this should never happen (unless it gets removed by Dexguard/Proguard/R8), this also removes this case from the error handler.
- Update Kotlin and AGP dependency to latest