### PR TITLE
Fix issue with annotated Kotlin function that were not inside a class when using ksp

### DIFF
--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkAnnotatedElement.kt
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkAnnotatedElement.kt
@@ -16,6 +16,7 @@
 package com.airbnb.deeplinkdispatch
 
 import androidx.room.compiler.processing.XElement
+import androidx.room.compiler.processing.XMemberContainer
 import androidx.room.compiler.processing.XMethodElement
 import androidx.room.compiler.processing.XTypeElement
 import java.net.MalformedURLException
@@ -23,9 +24,9 @@ import java.net.MalformedURLException
 sealed class DeepLinkAnnotatedElement @Throws(MalformedURLException::class) constructor(
     val uri: String,
     val element: XElement,
-    val annotatedClass: XTypeElement
+    val annotatedClass: XMemberContainer
 ) {
-    class MethodAnnotatedElement(uri: String, element: XMethodElement) : DeepLinkAnnotatedElement(uri, element, element.enclosingElement as XTypeElement) {
+    class MethodAnnotatedElement(uri: String, element: XMethodElement) : DeepLinkAnnotatedElement(uri, element, element.enclosingElement) {
         val method = element.name
     }
 

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/GenericWriter.kt
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/GenericWriter.kt
@@ -19,7 +19,7 @@ internal class GenericWriter : DocumetationWriter {
                 Documentor.formatJavaDoc(element.element.docComment)
                     ?.let { print(it) }
                 print(Documentor.PROPERTY_DELIMITER)
-                print(element.annotatedClass.qualifiedName)
+                print(element.annotatedClass.className.reflectionName())
                 when (element) {
                     is DeepLinkAnnotatedElement.MethodAnnotatedElement -> {
                         print(Documentor.CLASS_METHOD_NAME_DELIMITER)

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/MarkdownWriter.kt
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/MarkdownWriter.kt
@@ -36,7 +36,7 @@ internal class MarkdownWriter : DocumetationWriter {
                 is DeepLinkAnnotatedElement.MethodAnnotatedElement -> element.method
                 else -> ""
             }
-            val simpleName = element.annotatedClass.qualifiedName
+            val simpleName = element.annotatedClass.className.reflectionName()
             writer.println(
                 String.format(
                     Locale.US, format,

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkProcessorTest.kt
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkProcessorTest.kt
@@ -121,7 +121,7 @@ open class BaseDeepLinkProcessorTest {
 
         internal fun compileIncremental(
             sourceFiles: List<Source>,
-            customDeepLinks: List<String>?,
+            customDeepLinks: List<String> = emptyList(),
             useKsp: Boolean = false,
             incrementalFlag: Boolean = true
         ): CompileResult {
@@ -129,7 +129,7 @@ open class BaseDeepLinkProcessorTest {
             if (incrementalFlag) {
                 arguments["deepLink.incremental"] = "true"
             }
-            if (customDeepLinks != null) {
+            if (customDeepLinks.isNotEmpty()) {
                 arguments["deepLink.customAnnotations"] = customDeepLinks.joinToString(separator = "|")
             }
             return compile(

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.kt
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DeepLinkProcessorIncrementalTest.kt
@@ -280,12 +280,10 @@ class DeepLinkProcessorIncrementalTest : BaseDeepLinkProcessorTest() {
         val results = listOf(
             compileIncremental(
                 sourceFiles = sourceFiles,
-                customDeepLinks = null,
                 useKsp = false,
             ),
             compileIncremental(
                 sourceFiles = sourceFiles,
-                customDeepLinks = null,
                 useKsp = true,
             )
         )
@@ -353,12 +351,10 @@ class DeepLinkProcessorIncrementalTest : BaseDeepLinkProcessorTest() {
         val results = listOf(
             compileIncremental(
                 sourceFiles = sourceFiles,
-                customDeepLinks = null,
                 useKsp = false,
             ),
             compileIncremental(
                 sourceFiles = sourceFiles,
-                customDeepLinks = null,
                 useKsp = true,
             )
         )
@@ -380,7 +376,6 @@ class DeepLinkProcessorIncrementalTest : BaseDeepLinkProcessorTest() {
         val results = listOf(
             compileIncremental(
                 sourceFiles = sourceFiles,
-                customDeepLinks = null,
                 useKsp = false,
             ),
             // Need to disable for now because of bug in compile testing lib
@@ -463,12 +458,10 @@ class DeepLinkProcessorIncrementalTest : BaseDeepLinkProcessorTest() {
         val results = listOf(
             compileIncremental(
                 sourceFiles = sourceFiles,
-                customDeepLinks = null,
                 useKsp = false,
             ),
             compileIncremental(
                 sourceFiles = sourceFiles,
-                customDeepLinks = null,
                 useKsp = true,
             )
         )

--- a/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DocumentorTest.kt
+++ b/deeplinkdispatch-processor/src/test/java/com/airbnb/deeplinkdispatch/DocumentorTest.kt
@@ -1,9 +1,11 @@
 package com.airbnb.deeplinkdispatch
 
+import androidx.room.compiler.processing.XMemberContainer
 import androidx.room.compiler.processing.XMessager
 import androidx.room.compiler.processing.XMethodElement
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XTypeElement
+import com.squareup.javapoet.ClassName
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -58,12 +60,12 @@ class DocumentorTest {
         val classElement = mockk<XTypeElement>()
 
         every { classElement.docComment } returns "Sample doc \n @param empty \n @return nothing"
-        every { classElement.qualifiedName } returns "DocClass"
+        every { classElement.className } returns ClassName.get("", "DocClass")
 
         val methodElement = mockk<XMethodElement>(relaxed = true)
 
-        val element2Enclosed = mockk<XTypeElement>(relaxed = true)
-        every { element2Enclosed.qualifiedName } returns "DocClass"
+        val element2Enclosed = mockk<XMemberContainer>(relaxed = true)
+        every { element2Enclosed.className } returns ClassName.get("", "DocClass")
 
         every { methodElement.name } returns "DocMethod"
         every { methodElement.enclosingElement } returns element2Enclosed

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ def versions = [
     roboelectricVersion          : '4.5.1',
     benchmarkVersion             : '1.0.0',
     compileTestingVersion        : '1.4.2',
-    kspVersion                   : '1.5.10-1.0.0-beta02',
+    kspVersion                   : '1.5.10-1.0.0-beta01',
     xProcessorVersion            : '2.4.0-alpha03',
     mockkVersion                 : '1.11.0',
     ktlintGradlePluginVersion    : '3.4.5'


### PR DESCRIPTION
Make DeepLinkAnnotatedElement.annotatedClass an XMemberContainer as that also wraps the case when the method is not in an annotated class in the ksp case.

Added test for this usecase.