### PR TITLE
Fix sample app Activity class reference

### DIFF
--- a/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
+++ b/sample/src/main/java/com/airbnb/deeplinkdispatch/sample/MainActivity.java
@@ -54,7 +54,7 @@ public class MainActivity extends AppCompatActivity {
   public static class InnerClass {
     @DeepLink("dld://innerClassDeeplink")
     public static Intent intentForDeepLinkMethod(Context context) {
-      return new Intent(context, SecondActivity.class).setAction(ACTION_DEEP_LINK_INNER);
+      return new Intent(context, MainActivity.class).setAction(ACTION_DEEP_LINK_INNER);
     }
   }
 


### PR DESCRIPTION
Use MainActivity.class instead of SecondActivity.class
for inner class deep link Intent in sample app.

The Intent action used in the MainActivity inner class
is not relevant to SecondActivity.