### PR TITLE
Fix issues with long placeholders in hosts.

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
@@ -1217,8 +1217,8 @@ public final class DeepLinkUri {
      */
     private static String domainToAscii(String input) {
       try {
-        // When this is a template URI it might get to long with all the placeholder definitions
-        // to pass verification.
+        // When this is a template URI it might get to long (> 256 chars) with all the placeholder
+        // definitions to pass verification.
         // This will replace the placeholders with other shorter placeholders for URI validation.
         Set<String> placeholders = getPlaceHolders(input);
         String mappedInput = input;

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
@@ -1221,13 +1221,13 @@ public final class DeepLinkUri {
         String mappedInput = input;
         Map<String, String> placeholderMap = new HashMap(placeholders.size());
         int i = 0;
-        for(String placeholder: placeholders) {
-          String replacedValue = ""+(i++);
+        for (String placeholder : placeholders) {
+          String replacedValue = "" + (i++);
           mappedInput = mappedInput.replace(placeholder, replacedValue);
           placeholderMap.put(placeholder, replacedValue);
         }
         String result = IDN.toASCII(mappedInput).toLowerCase(Locale.US);
-        for(Map.Entry<String, String> entry : placeholderMap.entrySet()){
+        for (Map.Entry<String, String> entry : placeholderMap.entrySet()) {
           result = result.replace(entry.getValue(), entry.getKey());
         }
         if (result.isEmpty()) return null;

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
@@ -1217,6 +1217,9 @@ public final class DeepLinkUri {
      */
     private static String domainToAscii(String input) {
       try {
+        // When this is a template URI it might get to long with all the placeholder definitions
+        // to pass verification.
+        // This will replace the placeholders with other shorter placeholders for URI validation.
         Set<String> placeholders = getPlaceHolders(input);
         String mappedInput = input;
         Map<String, String> placeholderMap = new HashMap(placeholders.size());

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkUri.java
@@ -32,10 +32,12 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -321,7 +323,7 @@ public final class DeepLinkUri {
   }
 
   @NotNull
-  private Set<String> getPlaceHolders(String input) {
+  private static Set<String> getPlaceHolders(String input) {
     final Matcher matcher = PLACEHOLDER_REGEX.matcher(input);
     Set<String> placeholders = new HashSet<>(matcher.groupCount());
     while (matcher.find()) {
@@ -1215,7 +1217,19 @@ public final class DeepLinkUri {
      */
     private static String domainToAscii(String input) {
       try {
-        String result = IDN.toASCII(input).toLowerCase(Locale.US);
+        Set<String> placeholders = getPlaceHolders(input);
+        String mappedInput = input;
+        Map<String, String> placeholderMap = new HashMap(placeholders.size());
+        int i = 0;
+        for(String placeholder: placeholders) {
+          String replacedValue = ""+(i++);
+          mappedInput = mappedInput.replace(placeholder, replacedValue);
+          placeholderMap.put(placeholder, replacedValue);
+        }
+        String result = IDN.toASCII(mappedInput).toLowerCase(Locale.US);
+        for(Map.Entry<String, String> entry : placeholderMap.entrySet()){
+          result = result.replace(entry.getValue(), entry.getKey());
+        }
         if (result.isEmpty()) return null;
 
         if (result == null) return null;

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeeplinkUriTest.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/DeeplinkUriTest.kt
@@ -32,6 +32,17 @@ class DeeplinkUriTest {
     }
 
     @Test
+    fun testParseDeepLinkUriTemplateWithVeryLongHost() {
+        val host =
+            "www.example.{url_domain_suffix(just|a|lot|of|values|in|here|that|make|the|url|very|long|longer|than|264|characters|to|be|creating|some|problems|with|ID|decode)}"
+        val deeplinkUriTemplate = DeepLinkUri.parseTemplate("http{scheme_suffix}://$host/path1/path2")
+        assertNotNull(deeplinkUriTemplate)
+        assertEquals("http{scheme_suffix}", deeplinkUriTemplate.scheme())
+        assertEquals(host, deeplinkUriTemplate.host())
+        assertEquals(listOf("path1", "path2"), deeplinkUriTemplate.pathSegments())
+    }
+
+    @Test
     fun testParseDeepLinkUriTemplateWithOnlyPlaceholderAsHostAndScheme() {
         val deeplinkUriTemplate = DeepLinkUri.parseTemplate("{scheme}://{host}/path1/path2")
         assertNotNull(deeplinkUriTemplate)


### PR DESCRIPTION
Hosts can be very long if they have placeholders (in templates) and this might not process correctly. So we replace the placeholders with short ones and rereplace them after processing.

This is safe as this is only done for templates and placeholder format is well understood.

Added tests