### PR TITLE
Bump versions to fix xprocessing API change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ lib
 # intellij
 .idea
 *.iml
+*.hprof
 
 # eclipse
 .classpath

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.kt
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkProcessor.kt
@@ -298,9 +298,10 @@ class DeepLinkProcessor(symbolProcessorEnvironment: SymbolProcessorEnvironment? 
         val argsType = element.getAllMethods().singleOrNull {
             it.overrides(
                 other = handleDeepLinkInterfaceMethod,
-                owner = deepLinkHandlerInterface
+                owner = element
             )
-        }?.parameters?.last()?.type ?: error("Is not overriding method from interface. This is impossible.")
+        }?.parameters?.last()?.type
+            ?: error("Is not overriding method from interface. This is impossible.")
 
         val argsTypeElement = argsType.typeElement
         if (argsTypeElement?.isPublic() == false) {
@@ -363,7 +364,8 @@ class DeepLinkProcessor(symbolProcessorEnvironment: SymbolProcessorEnvironment? 
             )
         }
         if (element.getAllMethods()
-            .filter { it.name == deepLinkHandlerHandleDeepLinkMethodName && it.parameters.size == 2 }.count() != 1
+            .filter { it.name == deepLinkHandlerHandleDeepLinkMethodName && it.parameters.size == 2 }
+            .count() != 1
         ) {
             throw DeepLinkProcessorException(
                 element = element,
@@ -681,7 +683,11 @@ class DeepLinkProcessor(symbolProcessorEnvironment: SymbolProcessorEnvironment? 
     }
 
     private fun logError(element: XElement?, message: String) {
-        environment.messager.printMessage(Diagnostic.Kind.ERROR, message, element)
+        if (element != null) {
+            environment.messager.printMessage(Diagnostic.Kind.ERROR, message, element)
+        } else {
+            environment.messager.printMessage(Diagnostic.Kind.ERROR, message)
+        }
     }
 
     @Throws(IOException::class)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ def versions = [
     benchmarkVersion             : '1.0.0',
     compileTestingVersion        : '1.4.2',
     kspVersion                   : '1.5.31-1.0.0',
-    xProcessorVersion            : '2.4.0-alpha04',
+    xProcessorVersion            : '2.4.0-beta01',
     mockkVersion                 : '1.12.0',
     ktlintGradlePluginVersion    : '3.4.5'
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ POM_DEVELOPER_EMAIL=android@airbnb.com
 org.gradle.daemon=false
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1g


### PR DESCRIPTION
The new version of room/xprocessing has a breaking api change that is not backwards compatible (making a nullable param non null). Since we have updated to this new version in our other libraries it pushes the dependency up for this library as well, causing a compilation error. to solve we need to update in all libraries.

I also took some time to update other libraries too, notably AGP.

Tests also started failing, likely because of the xprocessing update, because I think the "overrides" function was using the wrong owner param. Not sure why it worked before - it's possible xprocessing changed this api behavior too.