### PR TITLE
Fix crash that could happen with no arg deep Link handler in R8 full mode.

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/ErrorHandler.kt
@@ -1,5 +1,13 @@
 package com.airbnb.deeplinkdispatch
 
-interface ErrorHandler {
-    fun duplicateMatch(uriString: String, duplicatedMatches: List<DeepLinkMatchResult>)
+abstract class ErrorHandler {
+    open fun duplicateMatch(uriString: String, duplicatedMatches: List<DeepLinkMatchResult>) {}
+
+    /**
+     * Called if unable to determine the type of an args class for a DeepLinkHandler.
+     * If this is the case we are just assuming no arguments and do not fail this might
+     * but this should not happen.
+     * This will give youyr pooportunity to log these cases.
+     */
+    open fun unableToDetermineHandlerArgsType(uriTemplate: String, className: String) {}
 }

--- a/deeplinkdispatch/proguard-rules.pro
+++ b/deeplinkdispatch/proguard-rules.pro
@@ -1,8 +1,16 @@
 # Keep the deep link handler classes (and INSTANCE field if they have it) as they are accessed
 # via reflection from within the app.
--keep class * extends com.airbnb.deeplinkdispatch.handler.DeepLinkHandler {
+-keep class * implements com.airbnb.deeplinkdispatch.handler.DeepLinkHandler {
     public static final ** INSTANCE;
 }
+
+# As per https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md in full mode
+# R8 will remove the Signature annotation inside the .dex file which is used to keep the generic
+# information. This still works if the generic type is anything other than java.lang.Object
+# but fails if the deep link has no arguments and thus the generic type of the handler is
+# java.lang.Object. To fix this we need to keep the interface even thogh keeping it for any
+# other reason is not required.
+-keep interface com.airbnb.deeplinkdispatch.handler.DeepLinkHandler
 
 # We need to keep the constructors of the argument objects used in the handleDeepLink methods.
 # As we instantiate those constructors at runtime and we rely on the full constructor to

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
@@ -155,7 +155,7 @@ class BaseDeepLinkDelegateTest {
         parameterMap: Map<String, String>
     ) = mapOf(DeepLinkUri.parse(url) to parameterMap)
 
-    private class DuplicatedMatchTestErrorHandler : ErrorHandler {
+    private class DuplicatedMatchTestErrorHandler : ErrorHandler() {
         var className: String = ""
         var duplicatedMatches: List<DeepLinkMatchResult>? = null
         var duplicateMatchCalled: Boolean = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.daemon=false
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1g
+# See https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md
+android.enableR8.fullMode=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip


### PR DESCRIPTION
The bytecode in the `.dex` file for the DeepLinkHander interface looks like this after normal compilation:

```smali
###### Class com.airbnb.deeplinkdispatch.handler.DeepLinkHandler (com.airbnb.deeplinkdispatch.handler.DeepLinkHandler)
.class public interface abstract Lcom/airbnb/deeplinkdispatch/handler/DeepLinkHandler;
.super Ljava/lang/Object;
.source "DeepLinkHandler.kt"


# annotations
.annotation system Ldalvik/annotation/Signature;
    value = {
        "<T:",
        "Ljava/lang/Object;",
        ">",
        "Ljava/lang/Object;"
    }
.end annotation
```

If we run R8 with full mode enabled on this it looks like this:

```smali
###### Class com.airbnb.deeplinkdispatch.handler.DeepLinkHandler (com.airbnb.deeplinkdispatch.handler.DeepLinkHandler)
.class public interface abstract Lcom/airbnb/deeplinkdispatch/handler/DeepLinkHandler;
.super Ljava/lang/Object;
```

The `dalvik/annotation/Signature` that describes the generic type got removed. (See https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md).

This is no issue at runtime as this is not needed and the generic type of anything implementing the interface is still kept.

e.g.

```smali
###### Class com.airbnb.deeplinkdispatch.sample.handler.SampleKotlinDeepLinkHandler (com.airbnb.deeplinkdispatch.sample.handler.SampleKotlinDeepLinkHandler)
.class public final Lcom/airbnb/deeplinkdispatch/sample/handler/SampleKotlinDeepLinkHandler;
.super Lcom/airbnb/deeplinkdispatch/sample/handler/IntermediateDeepLinkHandler1;


# annotations
.annotation runtime Lcom/airbnb/deeplinkdispatch/sample/WebDeepLink;
.end annotation

.annotation system Ldalvik/annotation/Signature;
    value = {
        "Lcom/airbnb/deeplinkdispatch/sample/handler/IntermediateDeepLinkHandler1<",
        "Lcom/airbnb/deeplinkdispatch/sample/handler/TestKotlinDeepLinkHandlerDeepLinkArgs;",
        ">;"
    }
.end annotation
```

but the type is fully erased if it is just `Any` e.g.

```smali
###### Class com.airbnb.deeplinkdispatch.sample.handler.SampleNoParamsKotlinDeepLinkHandler (com.airbnb.deeplinkdispatch.sample.handler.SampleNoParamsKotlinDeepLinkHandler)
.class public final Lcom/airbnb/deeplinkdispatch/sample/handler/SampleNoParamsKotlinDeepLinkHandler;
.super Ljava/lang/Object;

# interfaces
.implements Lcom/airbnb/deeplinkdispatch/handler/DeepLinkHandler;


# annotations
.annotation runtime Lcom/airbnb/deeplinkdispatch/sample/WebDeepLink;
.end annotation

.annotation system Ldalvik/annotation/Signature;
    value = {
        "Ljava/lang/Object;",
        "Lcom/airbnb/deeplinkdispatch/handler/DeepLinkHandler;"
    }
.end annotation

```

Directly keeping the `DeepLinkHandler` class is fixing this issue.
I also added some other code to make this safer and allow error reporting when type determination does not work.

- Keep deep link handler so tje signature attributes are also kept in the `.dex` file.
- Make `ErrorHandler` an abstract class so we can add error when type of deeplink handler args class cannot be determined.
- Fall back to `Any::class.java` when no type can be determined.
- Switch on R8 full mode to allow visibility into errors caused by full mode.
- Update gradle to latest.