### PR TITLE
use Gradle Daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_LICENSE_DIST=repo
 POM_DEVELOPER_ID=airbnb
 POM_DEVELOPER_NAME=Airbnb
 POM_DEVELOPER_EMAIL=android@airbnb.com
-org.gradle.daemon=false
+org.gradle.daemon=true
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1g


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
