### PR TITLE
Fix NPE in issue #351

### DIFF
--- a/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.kt
+++ b/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.kt
@@ -527,7 +527,7 @@ open class BaseDeepLinkDelegate @JvmOverloads constructor(
                 if (resultParameterMap.containsKey(queryParameter)) {
                     Log.w(TAG, "Duplicate parameter name in path and query param: $queryParameter")
                 }
-                resultParameterMap[queryParameter] = queryParameterValue
+                resultParameterMap[queryParameter] = queryParameterValue ?: ""
             }
         }
         return resultParameterMap

--- a/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
+++ b/deeplinkdispatch/src/test/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegateTest.kt
@@ -203,6 +203,21 @@ class BaseDeepLinkDelegateTest {
         assertThat(deepLinkEntry!!.equals(entry2))
     }
 
+    @Test
+    fun testMissingParameterValueReturnsEmptyString() {
+        val uriTemplate = "airbnb://foo"
+        val uri = mockk<Uri>()
+        every { uri.toString() } returns "airbnb://foo?q"
+        val entry = methodDeepLinkEntry(uriTemplate, TestDeepLinkClassStatic::class.java.name, "testMethod")
+        val activityMock = mockk<Activity>(relaxed = true)
+        val testDelegate = getOneRegistryTestDelegate(listOf(entry), null)
+        val intent = mockk<Intent>(relaxed = true)
+        every { intent.data } returns uri
+        every { activityMock.intent } returns intent
+        val result = testDelegate.createResult(activityMock, intent, testDelegate.findEntry(uriTemplate))
+        assertThat(result.parameters).isEqualTo(mapOf("q" to ""))
+    }
+
     private fun parameterMap(
         url: String,
         parameterMap: Map<String, String>


### PR DESCRIPTION
Issue #351 reports an NPE when query parameters do not have values, such as `schema://mycompany/search?q`. This PR fixes that issue by using empty strings for this case.