### PR TITLE
Fix snapshot release

### DIFF
--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -16,12 +16,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Update gradle.properties
         uses: DamianReeves/write-file-action@master
-          with:
-            path: gradle.properties
-            write-mode: append
-            contents: |
-              mavenCentralUsername=${{ secrets.NEXUS_USER }}
-              mavenCentralPassword=${{ secrets.NEXUS_PASSWORD }}
+        with:
+          path: gradle.properties
+          write-mode: append
+          contents: |
+            mavenCentralUsername=${{ secrets.NEXUS_USER }}
+            mavenCentralPassword=${{ secrets.NEXUS_PASSWORD }}
 
       - name: Deploy new snapshot of DeepLinkDispatch
         shell: bash

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@v2
       - name: Deploy new snapshot of DeepLinkDispatch
         shell: bash
-        run: ./gradlew publishAllPublicationsToMavenCentral
+        run: ./gradlew -PenforceSnapshotVersion=true publishAllPublicationsToMavenCentral

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -8,21 +8,21 @@ on:
 jobs:
   build-test:
     uses: airbnb/DeepLinkDispatch/.github/workflows/build_test.yml@master
-  update-gradle-properties:
-    uses: DamianReeves/write-file-action@master
-    with:
-      path: gradle.properties
-      contents: |
-        mavenCentralUsername=${{ secrets.NEXUS_USER }}
-        mavenCentralPassword=${{ secrets.NEXUS_PASSWORD }}
-
-      write-mode: append
   deploy-snapshot:
     needs: build-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout DeepLinkDispatch
         uses: actions/checkout@v2
+      - name: Update gradle.properties
+        uses: DamianReeves/write-file-action@master
+          with:
+            path: gradle.properties
+            write-mode: append
+            contents: |
+              mavenCentralUsername=${{ secrets.NEXUS_USER }}
+              mavenCentralPassword=${{ secrets.NEXUS_PASSWORD }}
+
       - name: Deploy new snapshot of DeepLinkDispatch
         shell: bash
         run: ./gradlew -PenforceSnapshotVersion=true publishAllPublicationsToMavenCentral

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -8,6 +8,15 @@ on:
 jobs:
   build-test:
     uses: airbnb/DeepLinkDispatch/.github/workflows/build_test.yml@master
+  update-gradle-properties:
+    uses: DamianReeves/write-file-action@master
+    with:
+      path: gradle.properties
+      contents: |
+        mavenCentralUsername=${{ secrets.NEXUS_USER }}
+        mavenCentralPassword=${{ secrets.NEXUS_PASSWORD }}
+
+      write-mode: append
   deploy-snapshot:
     needs: build-test
     runs-on: ubuntu-latest
@@ -16,7 +25,4 @@ jobs:
         uses: actions/checkout@v2
       - name: Deploy new snapshot of DeepLinkDispatch
         shell: bash
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-        run: ./gradlew uploadArchives
+        run: ./gradlew publishAllPublicationsToMavenCentral

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -20,6 +20,11 @@ publishing {
 }
 
 mavenPublishing {
+    if (findProperty("enforceSnapshotVersion").toString().toBoolean() && !findProperty("VERSION_NAME").toString().endsWith("-SNAPSHOT")) {
+        throw new org.gradle.api.tasks.TaskInstantiationException(
+                "Cannot publish non snapshot version(${findProperty("VERSION_NAME")}) if 'enforceSnapshotVersion' property is set!"
+        )
+    }
     if (findProperty("doNotSignRelease").toString().toBoolean()) {
         println("Skipping release signing")
     } else {


### PR DESCRIPTION
Append secrets to existing `gradle.properites` file to avoid having to print them on cli (which would be redacted but still)

Update snapshot publish