### PR TITLE
Fix matching issue with placeholders

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -410,9 +410,12 @@ public class MatchIndex {
                               + new String(placeholderValue), false);
             } else return null;
           }
-          // We do the comparison from the back if the value in the index (before the placeholder starts
-          // is longer than valueToMatch we need to abort.
-          if (k >= 0 || byteArray[valueStartPos + j] != valueToMatch[k]) {
+          // We do the comparison from the back. If the value in the index (before the placeholder
+          // starts) is longer than valueToMatch we need to abort.
+          // e.g. template value: "{something}longer" and valueToMatch: "onger". As we compare
+          // from back all the chars match but the template value is longer so as soon as we reach
+          // the end of valueToMatch before we reach the placeholder end char we need to abort.
+          if (k < 0 || byteArray[valueStartPos + j] != valueToMatch[k]) {
             return null;
           }
         }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/MatchIndex.java
@@ -410,7 +410,9 @@ public class MatchIndex {
                               + new String(placeholderValue), false);
             } else return null;
           }
-          if (byteArray[valueStartPos + j] != valueToMatch[k]) {
+          // We do the comparison from the back if the value in the index (before the placeholder starts
+          // is longer than valueToMatch we need to abort.
+          if (k >= 0 || byteArray[valueStartPos + j] != valueToMatch[k]) {
             return null;
           }
         }

--- a/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/MatchIndexTests.kt
+++ b/deeplinkdispatch-base/src/test/java/com/airbnb/deeplinkdispatch/MatchIndexTests.kt
@@ -1,6 +1,5 @@
 package com.airbnb.deeplinkdispatch
 
-import com.airbnb.deeplinkdispatch.base.MatchIndex
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -29,9 +28,8 @@ class MatchIndexTests {
         entryWithAllowedValueAndLongerValueThan
     ).sortedBy { it.uriTemplate }
 
-
     @Test
-    fun testMatchWithPlaceholderThatEndsInSegmentWithLongerMatch(){
+    fun testMatchWithPlaceholderThatEndsInSegmentWithLongerMatch() {
         // This is testing a condition where an URL segment (in this case the host) has a placeholder with allowed values
         // in the template and is matching (from the back) to what is in the to be matched URL, where the entry in the template
         // is matching but longer (and thus not matching) before the placeholder starts (from the back).


### PR DESCRIPTION
If a match template contained a placeholder in a path element (e.g. host) and the to be matched URL element matched but was just shorter than the template (before the placeholder end) it would lead to an AIOOB Exception.

e.g.

template: `scheme://{some_value(allowed|values)}somethinglonger/one/{param}/three`
url to match `scheme://longer/one/param/three`

Scheme matches
host (will start to match from back) and it matches char by char bur the one in the template is longer (before the placeholder) in this case we need to avoid the AIOOB in url segment and it also does not match.