### PR TITLE
Optimize chunkOnModifiedUtf8ByteSize from O(n²) to O(n)

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/Utils.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/base/Utils.kt
@@ -17,7 +17,7 @@ import java.io.InputStream
 private fun Char.modifiedUtf8ByteSize(): Int {
     val codePoint = this.code
     return when {
-        codePoint == 0 -> 2  // Null character is encoded as 2 bytes in Modified UTF-8
+        codePoint == 0 -> 2 // Null character is encoded as 2 bytes in Modified UTF-8
         codePoint <= 0x7F -> 1
         codePoint <= 0x7FF -> 2
         else -> 3


### PR DESCRIPTION
## Summary

- Fixes O(n²) performance issue in `chunkOnModifiedUtf8ByteSize` that caused significant build time overhead
- Implements incremental byte size calculation instead of creating substrings for each character
- Adds a helper function to calculate Modified UTF-8 byte size per character

## Background

This addresses the performance issue reported in #350. The original implementation created a new substring and converted it to a byte array for **every character** in the input string:

```kotlin
// Before: O(n²) - substring + toByteArray for each iteration
val charModifiedUtf8ByteArraySize =
    this
        .substring(nextChunkStart, i + 1)
        .let { chunk -> chunk.toByteArray().size + chunk.count { char -> char == '\u0000' } }
```

This is now replaced with an O(n) approach that calculates byte sizes incrementally:

```kotlin
// After: O(n) - direct calculation per character
val charByteSize = this[i].modifiedUtf8ByteSize()
```

## Technical Details

The new `modifiedUtf8ByteSize()` helper function handles Modified UTF-8 encoding rules:
- U+0000 (null): 2 bytes (C0 80 encoding - special for Modified UTF-8)
- U+0001-U+007F: 1 byte
- U+0080-U+07FF: 2 bytes
- U+0800-U+FFFF: 3 bytes

## Testing

All existing tests in `CharSequenceUtf8Test` pass, confirming behavioral correctness.