### PR TITLE
Centralize toolchain and target compatibility version.

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout DeepLinkDispatch
         uses: actions/checkout@v2
       - name: Set up JDK 22
-        uses: [actions/setup-java](https://github.com/actions/setup-java)@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '22'
           distribution: 'coretto'
+          java-version: '22'
       - name: Build/Test DeepLinkDispatch
         run: ./gradlew assemble check javadoc lintKotlin

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK 22
         uses: actions/setup-java@v5
         with:
-          distribution: 'coretto'
+          distribution: 'corretto'
           java-version: '22'
       - name: Build/Test DeepLinkDispatch
         run: ./gradlew assemble check javadoc lintKotlin

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -11,5 +11,10 @@ jobs:
     steps:
       - name: Checkout DeepLinkDispatch
         uses: actions/checkout@v2
+      - name: Set up JDK 22
+        uses: [actions/setup-java](https://github.com/actions/setup-java)@v4
+        with:
+          java-version: '22'
+          distribution: 'coretto'
       - name: Build/Test DeepLinkDispatch
         run: ./gradlew assemble check javadoc lintKotlin

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout DeepLinkDispatch
         uses: actions/checkout@v2
       - name: Set up JDK 22
-        uses: [actions/setup-java](https://github.com/actions/setup-java)@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '22'
           distribution: 'coretto'
+          java-version: '22'
       - name: Update gradle.properties
         uses: DamianReeves/write-file-action@master
         with:

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK 22
         uses: actions/setup-java@v5
         with:
-          distribution: 'coretto'
+          distribution: 'corretto'
           java-version: '22'
       - name: Update gradle.properties
         uses: DamianReeves/write-file-action@master

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - name: Checkout DeepLinkDispatch
         uses: actions/checkout@v2
+      - name: Set up JDK 22
+        uses: [actions/setup-java](https://github.com/actions/setup-java)@v4
+        with:
+          java-version: '22'
+          distribution: 'coretto'
       - name: Update gradle.properties
         uses: DamianReeves/write-file-action@master
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,53 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     }
 }
 
+// Apply consistent JVM toolchain and target to all subprojects
+subprojects {
+    afterEvaluate {
+        def toolchainVersion = rootProject.ext.jvmToolchainVersion
+        def targetVersion = rootProject.ext.jvmTargetVersion
+
+        // For Kotlin projects (both pure JVM and Android)
+        if (plugins.hasPlugin('org.jetbrains.kotlin.jvm') || plugins.hasPlugin('kotlin') ||
+            plugins.hasPlugin('kotlin-android') || plugins.hasPlugin('org.jetbrains.kotlin.android')) {
+            kotlin {
+                jvmToolchain(toolchainVersion)
+            }
+            tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                compilerOptions {
+                    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.@Companion.fromTarget(targetVersion.toString())
+                }
+            }
+        }
+        // For Java-only projects (without Kotlin)
+        else if (plugins.hasPlugin('java') && !plugins.hasPlugin('kotlin-dsl')) {
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(toolchainVersion)
+                }
+            }
+        }
+
+        // For Android projects, also set compileOptions
+        if (plugins.hasPlugin('com.android.library') || plugins.hasPlugin('com.android.application')) {
+            android {
+                compileOptions {
+                    sourceCompatibility = JavaVersion.toVersion(targetVersion)
+                    targetCompatibility = JavaVersion.toVersion(targetVersion)
+                }
+            }
+        }
+
+        // For pure Java projects
+        if (plugins.hasPlugin('java') && !plugins.hasPlugin('kotlin-dsl')) {
+            java {
+                sourceCompatibility = JavaVersion.toVersion(targetVersion)
+                targetCompatibility = JavaVersion.toVersion(targetVersion)
+            }
+        }
+    }
+}
+
 def getReleaseRepositoryUrl() {
     return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
             : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"

--- a/deeplinkdispatch-base/build.gradle
+++ b/deeplinkdispatch-base/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'org.jmailen.kotlinter'
@@ -7,20 +5,12 @@ apply plugin: 'org.jmailen.kotlinter'
 apply plugin: 'checkstyle'
 apply from: '../publishing.gradle'
 
-kotlin {
-    jvmToolchain(11)
-}
-
 dependencies {
   implementation deps.okio
   implementation deps.jsr305
   implementation deps.androidXAnnotations
   testImplementation deps.junit
   testImplementation deps.assertJ
-}
-
-kotlin.compilerOptions {
-    jvmTarget = JvmTarget.JVM_11
 }
 
 checkstyle {

--- a/deeplinkdispatch-gradle-plugin/build.gradle.kts
+++ b/deeplinkdispatch-gradle-plugin/build.gradle.kts
@@ -4,6 +4,8 @@ apply(from = "$rootDir/dependencies.gradle")
 apply(from = "$rootDir/publishing.gradle")
 
 val deps: Map<String, Any> by project
+val jvmToolchainVersion: Int by rootProject.extra
+val jvmTargetVersion: Int by rootProject.extra
 
 repositories {
     google()
@@ -17,13 +19,17 @@ plugins {
     `java-gradle-plugin`
 }
 
+// JVM toolchain and target - uses central versions from dependencies.gradle
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(jvmToolchainVersion))
+    }
+    sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
+    targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
 }
 
 kotlin.compilerOptions {
-    jvmTarget = JvmTarget.JVM_11
+    jvmTarget = JvmTarget.fromTarget(jvmTargetVersion.toString())
 }
 
 gradlePlugin {

--- a/deeplinkdispatch-processor/build.gradle
+++ b/deeplinkdispatch-processor/build.gradle
@@ -4,10 +4,6 @@ apply plugin: 'org.jmailen.kotlinter'
 apply plugin: 'checkstyle'
 apply from: '../publishing.gradle'
 
-kotlin {
-  jvmToolchain(11)
-}
-
 dependencies {
   implementation project(':deeplinkdispatch-base')
   implementation deps.jsr305

--- a/deeplinkdispatch/build.gradle
+++ b/deeplinkdispatch/build.gradle
@@ -36,7 +36,3 @@ android {
     unitTests.returnDefaultValues = true
   }
 }
-
-kotlin {
-  jvmToolchain(11)
-}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,6 +35,10 @@ ext.androidConfig = [
     targetSdkVersion                    : 35
 ]
 
+// Central JVM configuration for all modules
+ext.jvmToolchainVersion = 22  // JDK used for compilation
+ext.jvmTargetVersion = 11     // Bytecode target (compatibility)
+
 ext.versions = versions
 
 ext.deps = [

--- a/sample-benchmark/build.gradle
+++ b/sample-benchmark/build.gradle
@@ -25,10 +25,6 @@ android {
     }
 }
 
-kotlin {
-  jvmToolchain(11)
-}
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 

--- a/sample-benchmarkable-library/build.gradle
+++ b/sample-benchmarkable-library/build.gradle
@@ -19,12 +19,6 @@ android {
   }
 }
 
-java {
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
-  }
-}
-
 dependencies {
   implementation project(':deeplinkdispatch')
   annotationProcessor project(':deeplinkdispatch-processor')

--- a/sample-kapt-library/build.gradle
+++ b/sample-kapt-library/build.gradle
@@ -26,10 +26,6 @@ android {
   }
 }
 
-kotlin {
-  jvmToolchain(11)
-}
-
 dependencies {
   implementation project(':deeplinkdispatch')
   kapt project(':deeplinkdispatch-processor')

--- a/sample-ksp-library/build.gradle
+++ b/sample-ksp-library/build.gradle
@@ -32,15 +32,6 @@ android {
     namespace = "com.airbnb.deeplinkdispatch.sampleksplibrary"
     compileSdk androidConfig.compileSdkVersion
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = '11'
-    }
-
     defaultConfig {
         minSdk = androidConfig.minSdkVersion
         targetSdk = androidConfig.compileSdkVersion

--- a/sample-library/build.gradle
+++ b/sample-library/build.gradle
@@ -21,10 +21,6 @@ android {
   }
 }
 
-kotlin {
-  jvmToolchain(11)
-}
-
 dependencies {
   implementation project(':deeplinkdispatch')
   annotationProcessor project(':deeplinkdispatch-processor')

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -43,10 +43,6 @@ android {
     }
 }
 
-kotlin {
-  jvmToolchain(17)
-}
-
 dependencies {
     implementation project(':deeplinkdispatch')
     ksp project(':deeplinkdispatch-processor')


### PR DESCRIPTION
Use 22 for toolchain and 11 for source compatibility.