### PR TITLE
Fix warning log

### DIFF
--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/metadata/ManifestGenerator.kt
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/metadata/ManifestGenerator.kt
@@ -105,7 +105,7 @@ internal class ManifestGenerator(
                 }
             manifestWritten = true
             messager.printMessage(
-                Diagnostic.Kind.WARNING,
+                Diagnostic.Kind.NOTE,
                 " Manifest generation: Generated at KSP resource output: ${ManifestGeneration.MANIFEST_RESOURCE_PATH}",
             )
         } catch (e: Exception) {

--- a/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/metadata/ManifestGenerator.kt
+++ b/deeplinkdispatch-processor/src/main/java/com/airbnb/deeplinkdispatch/metadata/ManifestGenerator.kt
@@ -106,12 +106,12 @@ internal class ManifestGenerator(
             manifestWritten = true
             messager.printMessage(
                 Diagnostic.Kind.NOTE,
-                " Manifest generation: Generated at KSP resource output: ${ManifestGeneration.MANIFEST_RESOURCE_PATH}",
+                "Manifest generation: Generated at KSP resource output: ${ManifestGeneration.MANIFEST_RESOURCE_PATH}",
             )
         } catch (e: Exception) {
             messager.printMessage(
                 Diagnostic.Kind.ERROR,
-                " Manifest generation failed: ${e.message}",
+                "Manifest generation failed: ${e.message}",
             )
         }
     }


### PR DESCRIPTION
I think the Manifest success log should be a `Note` log instead of a `Warning`. It's causing noise on the build output:

<img width="744" height="77" alt="Screenshot 2026-04-02 at 08 32 40" src="https://github.com/user-attachments/assets/3dd8dd7a-4170-4e63-8444-d9690fb12e8d" />
